### PR TITLE
Add resizable board and images

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,5 +10,10 @@
 
 .non-selectable {
     user-select: none; /* Prevents text selection */
-    pointer-events: none; /* Prevents mouse events, including selection */
-  }
+  pointer-events: none; /* Prevents mouse events, including selection */
+}
+
+.resize-handle {
+    pointer-events: all;
+    cursor: nwse-resize;
+}

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
-import { debugTooltip, makeDraggable } from '../d3-ext';
+import { debugTooltip, makeDraggable, makeResizable } from '../d3-ext';
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';
@@ -114,6 +114,7 @@ const GuitarBoard: React.FC = () => {
       .attr('height', 100);
 
     group.call(makeDraggable);
+    group.call(makeResizable);
 
     return group;
   }
@@ -230,6 +231,7 @@ const GuitarBoard: React.FC = () => {
     svg.append('g').attr('class', 'pasted-images');
 
     board.call(makeDraggable);
+    board.call(makeResizable);
 
     drawBoard();
 


### PR DESCRIPTION
## Summary
- update draggable logic to keep scaling state
- implement a `makeResizable` helper with a drag handle
- allow pasted images and the board to be resized
- style resize handles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685697a200d0832eb26f4c4f3e4f133b