### PR TITLE
Add rotation feature for draggable elements

### DIFF
--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -127,7 +127,7 @@ const GuitarBoard: React.FC = () => {
       .attr('height', 100);
 
     group.call(makeDraggable);
-    group.call(makeResizable);
+    group.call(makeResizable, { rotatable: true });
 
     group.dispatch('click');
 
@@ -167,7 +167,7 @@ const GuitarBoard: React.FC = () => {
       .attr('allowFullScreen', 'true');
 
     group.call(makeDraggable);
-    group.call(makeResizable, { lockAspectRatio: true });
+    group.call(makeResizable, { lockAspectRatio: true, rotatable: true });
 
     group.dispatch('click');
 
@@ -295,7 +295,7 @@ const GuitarBoard: React.FC = () => {
     svg.append('g').attr('class', 'embedded-videos');
 
     board.call(makeDraggable);
-    board.call(makeResizable);
+    board.call(makeResizable, { rotatable: true });
 
     drawBoard();
 

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -117,7 +117,7 @@ const GuitarBoard: React.FC = () => {
 
     const group = imagesLayer.append('g')
       .attr('class', 'pasted-image')
-      .datum<PastedImageDatum>({ src });
+      .datum<PastedImageDatum & { transform: any }>({ src, transform: { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 } });
 
     group.append('image')
       .attr('href', src)
@@ -143,7 +143,7 @@ const GuitarBoard: React.FC = () => {
 
     const group = videosLayer.append('g')
       .attr('class', 'embedded-video')
-      .datum<PastedVideoDatum>({ url, videoId });
+      .datum<PastedVideoDatum & { transform: any }>({ url, videoId, transform: { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 } });
 
     group.append('rect')
       .attr('x', 0)
@@ -290,7 +290,8 @@ const GuitarBoard: React.FC = () => {
     let board = svg.select<SVGGElement>('.guitar-board');
     if (!board.empty()) return;
 
-    board = svg.append('g').attr('class', 'guitar-board');
+    board = svg.append('g').attr('class', 'guitar-board')
+      .datum<{ transform: any }>({ transform: { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 } });
     svg.append('g').attr('class', 'pasted-images');
     svg.append('g').attr('class', 'embedded-videos');
 


### PR DESCRIPTION
## Summary
- support storing rotate transforms and helper utils
- allow dragging/resizing while keeping rotation
- display rotate handle and enable rotation via drag
- enable rotation for guitar board items

## Testing
- `npm run build` *(fails: Cannot find module '@eslint/js' etc.)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856b7927270832eb7e3c22a7d7a3c1d