### PR TITLE
Add sticky note support for pasted text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://sergej-popov.github.io/tremolo/
 - Drag and resize the guitar board.
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.
+- Paste text to create sticky notes that can be dragged, resized and rotated.
 - Select a pasted object and press **Delete** to remove it.
 - Quickly add predefined chords or scales or display all notes.
 
@@ -19,7 +20,7 @@ https://sergej-popov.github.io/tremolo/
 
 ## TODO
 1. Add ability to crop images through makeCroppable. Only images to be croppable. Crop must not be permanent. When cropping an already cropped element, I should be able to recover the previously cropped space. So, essentially the cropping should be done by masking. Area outside of mask should be semi transparent. Crop is triggered by 'c' hotkey.
-2. Add an ability to paste text. When text is pasted, it should be draggable and editable. Text should not be resizable. However when Up and Down arrow keys are pressed, the text font size should increase or decrease.
+2. ~~Add an ability to paste text. When text is pasted, it should be draggable and editable. Text should not be resizable. However when Up and Down arrow keys are pressed, the text font size should increase or decrease.~~ Implemented as sticky notes that can be rotated and resized.
 3. Export the current board as an image.
 4. Save and load board layouts from local storage.
 5. Provide an option to toggle note names on or off.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://sergej-popov.github.io/tremolo/
 - Drag and resize the guitar board.
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.
-- Paste text to create sticky notes that can be dragged, resized and rotated.
+- Paste text to create sticky notes that can be dragged, resized and rotated. Double-click a sticky note to edit its text.
 - Select a pasted object and press **Delete** to remove it.
 - Quickly add predefined chords or scales or display all notes.
 

--- a/src/App.css
+++ b/src/App.css
@@ -17,3 +17,7 @@
     pointer-events: all;
     cursor: nwse-resize;
 }
+
+.sticky-note div {
+    outline: none;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -21,3 +21,13 @@
 .sticky-note div {
     outline: none;
 }
+
+.sticky-text.view-mode {
+    user-select: none;
+    pointer-events: none;
+}
+
+.sticky-text.edit-mode {
+    user-select: text;
+    pointer-events: all;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -30,4 +30,5 @@
 .sticky-text.edit-mode {
     user-select: text;
     pointer-events: all;
+    caret-color: black; /* Ensure the cursor is visible */
 }

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -201,16 +201,38 @@ const GuitarBoard: React.FC = () => {
       .attr('width', stickyWidth)
       .attr('height', stickyHeight);
 
-    fo.append('xhtml:div')
+    const div = fo.append('xhtml:div')
+      .classed('sticky-text', true)
+      .classed('view-mode', true)
       .style('width', '100%')
       .style('height', '100%')
       .style('box-sizing', 'border-box')
       .style('font-family', 'Segoe UI')
       .style('padding', '4px')
       .style('overflow', 'hidden')
-      .attr('contentEditable', 'true')
-      .text(text)
-      .on('mousedown', (event: MouseEvent) => event.stopPropagation());
+      .text(text);
+
+    group.on('dblclick', () => {
+      div
+        .attr('contentEditable', 'true')
+        .classed('view-mode', false)
+        .classed('edit-mode', true)
+        .on('mousedown.edit', (event: MouseEvent) => event.stopPropagation());
+
+      setTimeout(() => {
+        (div.node() as HTMLDivElement)?.focus();
+      }, 0);
+    });
+
+    div.on('blur', () => {
+      const data = group.datum() as StickyNoteDatum & { transform: any };
+      data.text = div.text();
+      div
+        .attr('contentEditable', 'false')
+        .classed('edit-mode', false)
+        .classed('view-mode', true)
+        .on('mousedown.edit', null);
+    });
 
     group.call(makeDraggable);
     group.call(makeResizable, { rotatable: true });


### PR DESCRIPTION
## Summary
- allow pasting text to create sticky notes
- make sticky notes draggable, resizable, and rotatable
- initialize sticky note layer in the board
- document sticky notes in README
- add minor CSS for sticky notes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6856bb58e258832e8e891eafaf249a6b