### PR TITLE
Add crop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@ https://sergej-popov.github.io/tremolo/
 
 ## Hotkeys
 - **Delete** – remove the selected item.
-- **c** – crop selected image (planned).
+ - **c** – crop selected image.
 
 ## TODO
-1. Add ability to crop images through makeCroppable. Only images to be croppable. Crop must not be permanent. When cropping an already cropped element, I should be able to recover the previously cropped space. So, essentially the cropping should be done by masking. Area outside of mask should be semi transparent. Crop is triggered by 'c' hotkey.
-2. ~~Add an ability to paste text. When text is pasted, it should be draggable and editable. Text should not be resizable. However when Up and Down arrow keys are pressed, the text font size should increase or decrease.~~ Implemented as sticky notes that can be rotated and resized.
-3. Export the current board as an image.
-4. Save and load board layouts from local storage.
-5. Provide an option to toggle note names on or off.
-6. Provide undo and redo support for board changes.
-7. Allow items to snap to a grid for precise alignment.
-8. Add a dark and light theme toggle for the fretboard interface.
+1. ~~Add an ability to paste text. When text is pasted, it should be draggable and editable. Text should not be resizable. However when Up and Down arrow keys are pressed, the text font size should increase or decrease.~~ Implemented as sticky notes that can be rotated and resized.
+2. Export the current board as an image.
+3. Save and load board layouts from local storage.
+4. Provide an option to toggle note names on or off.
+5. Provide undo and redo support for board changes.
+6. Allow items to snap to a grid for precise alignment.
+7. Add a dark and light theme toggle for the fretboard interface.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://sergej-popov.github.io/tremolo/
 
 ## Hotkeys
 - **Delete** – remove the selected item.
- - **c** – crop selected image.
+- **c** – crop selected image (or double-click an image to toggle cropping).
 
 ## TODO
 1. ~~Add an ability to paste text. When text is pasted, it should be draggable and editable. Text should not be resizable. However when Up and Down arrow keys are pressed, the text font size should increase or decrease.~~ Implemented as sticky notes that can be rotated and resized.

--- a/src/App.css
+++ b/src/App.css
@@ -32,3 +32,26 @@
     pointer-events: all;
     caret-color: black; /* Ensure the cursor is visible */
 }
+
+.crop-controls {
+    pointer-events: none;
+}
+
+.crop-rect {
+    pointer-events: all;
+    stroke-dasharray: 4;
+}
+
+.crop-handle {
+    pointer-events: all;
+    cursor: nwse-resize;
+    fill: white;
+    stroke: black;
+}
+
+.crop-shade-top,
+.crop-shade-right,
+.crop-shade-bottom,
+.crop-shade-left {
+    fill: rgba(0, 0, 0, 0.3);
+}

--- a/src/App.css
+++ b/src/App.css
@@ -38,15 +38,24 @@
 }
 
 .crop-rect {
-    pointer-events: all;
+    pointer-events: none;
     stroke-dasharray: 4;
 }
 
 .crop-handle {
     pointer-events: all;
-    cursor: nwse-resize;
     fill: white;
     stroke: black;
+}
+
+.crop-handle-n,
+.crop-handle-s {
+    cursor: ns-resize;
+}
+
+.crop-handle-e,
+.crop-handle-w {
+    cursor: ew-resize;
 }
 
 .crop-shade-top,

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
-import { debugTooltip, makeDraggable, makeResizable } from '../d3-ext';
+import { debugTooltip, makeDraggable, makeResizable, makeCroppable } from '../d3-ext';
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';
@@ -133,6 +133,7 @@ const GuitarBoard: React.FC = () => {
 
     group.call(makeDraggable);
     group.call(makeResizable, { rotatable: true });
+    group.call(makeCroppable);
 
     group.dispatch('click');
 

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -312,12 +312,16 @@ function updateCropOverlay(element: Selection<any, any, any, any>) {
     const overlay = element.select('.crop-controls');
     const rect = overlay.select<SVGRectElement>('.crop-rect');
 
-    const imgWidth = parseFloat(image.attr('width'));
-    const imgHeight = parseFloat(image.attr('height'));
-    const x = parseFloat(rect.attr('x'));
-    const y = parseFloat(rect.attr('y'));
-    const width = parseFloat(rect.attr('width'));
-    const height = parseFloat(rect.attr('height'));
+    const imgWidth = parseFloat(image.attr('width') ?? '0');
+    const imgHeight = parseFloat(image.attr('height') ?? '0');
+    const x = parseFloat(rect.attr('x') ?? '0');
+    const y = parseFloat(rect.attr('y') ?? '0');
+    const width = parseFloat(rect.attr('width') ?? '0');
+    const height = parseFloat(rect.attr('height') ?? '0');
+
+    if ([imgWidth, imgHeight, x, y, width, height].some(v => isNaN(v))) {
+        return;
+    }
 
     overlay.select('.crop-handle-n')
         .attr('cx', x + width / 2)
@@ -367,6 +371,10 @@ function startCrop(element: Selection<any, any, any, any>) {
         data.crop = crop;
         element.datum(data);
     }
+    crop.x = crop.x ?? 0;
+    crop.y = crop.y ?? 0;
+    crop.width = crop.width ?? 0;
+    crop.height = crop.height ?? 0;
     const overlay = element.select('.crop-controls');
     const rect = overlay.select('.crop-rect');
     rect
@@ -386,10 +394,10 @@ function finishCrop(element: Selection<any, any, any, any>) {
     const clipRect = element.select('.clip-rect');
     const data = element.datum() as any;
 
-    const x = parseFloat(rect.attr('x'));
-    const y = parseFloat(rect.attr('y'));
-    const width = parseFloat(rect.attr('width'));
-    const height = parseFloat(rect.attr('height'));
+    const x = parseFloat(rect.attr('x') ?? '0');
+    const y = parseFloat(rect.attr('y') ?? '0');
+    const width = parseFloat(rect.attr('width') ?? '0');
+    const height = parseFloat(rect.attr('height') ?? '0');
 
     data.crop = { x, y, width, height } as CropValues;
 
@@ -473,8 +481,8 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleN.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
-                        const y = parseFloat(rect.attr('y'));
-                        const height = parseFloat(rect.attr('height'));
+                        const y = parseFloat(rect.attr('y') ?? '0');
+                        const height = parseFloat(rect.attr('height') ?? '0');
                         d3.select(this).datum({ startY: event.y, y, height });
                     })
                     .on('drag', function (event: MouseEvent) {
@@ -490,7 +498,7 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleS.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
-                        const height = parseFloat(rect.attr('height'));
+                        const height = parseFloat(rect.attr('height') ?? '0');
                         d3.select(this).datum({ startY: event.y, height });
                     })
                     .on('drag', function (event: MouseEvent) {
@@ -505,7 +513,7 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleE.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
-                        const width = parseFloat(rect.attr('width'));
+                        const width = parseFloat(rect.attr('width') ?? '0');
                         d3.select(this).datum({ startX: event.x, width });
                     })
                     .on('drag', function (event: MouseEvent) {
@@ -520,8 +528,8 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleW.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
-                        const x = parseFloat(rect.attr('x'));
-                        const width = parseFloat(rect.attr('width'));
+                        const x = parseFloat(rect.attr('x') ?? '0');
+                        const width = parseFloat(rect.attr('width') ?? '0');
                         d3.select(this).datum({ startX: event.x, x, width });
                     })
                     .on('drag', function (event: MouseEvent) {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -86,6 +86,10 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
         d3.drag()
             .on('start', function (event: MouseEvent) {
                 const element = d3.select(this);
+                const overlay = element.select('.crop-controls');
+                if (!overlay.empty() && overlay.style('display') !== 'none') {
+                    finishCrop(element);
+                }
                 const data: any = element.datum();
                 const transform: TransformValues = data.transform ?? defaultTransform();
 
@@ -144,6 +148,11 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
             .on('start', function (event: MouseEvent) {
                 const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
                 if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
+
+                const overlay = element.select('.crop-controls');
+                if (!overlay.empty() && overlay.style('display') !== 'none') {
+                    finishCrop(element);
+                }
 
                 const bbox = (element.node() as SVGGraphicsElement).getBBox();
                 const data = element.datum() as any;
@@ -206,6 +215,11 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
                     const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
                     if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
 
+                    const overlay = element.select('.crop-controls');
+                    if (!overlay.empty() && overlay.style('display') !== 'none') {
+                        finishCrop(element);
+                    }
+
                     const data = element.datum() as any;
                     const transform: TransformValues = data.transform ?? defaultTransform();
                     data.transform = transform;
@@ -249,6 +263,11 @@ function addOutline(element: Selection<any, any, any, any>) {
 
 function clearSelection() {
     if (!selectedElement) return;
+    // finish active crop before clearing selection
+    const overlay = selectedElement.select('.crop-controls');
+    if (!overlay.empty() && overlay.style('display') !== 'none') {
+        finishCrop(selectedElement);
+    }
     selectedElement.selectAll('.selection-outline').remove();
     selectedElement.selectAll('.resize-handle').remove();
     selectedElement.selectAll('.rotate-handle').remove();
@@ -481,6 +500,8 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleN.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
+                        const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
+                        if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const y = parseFloat(rect.attr('y') ?? '0');
                         const height = parseFloat(rect.attr('height') ?? '0');
                         d3.select(this).datum({ startY: event.y, y, height });
@@ -498,6 +519,8 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleS.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
+                        const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
+                        if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const height = parseFloat(rect.attr('height') ?? '0');
                         d3.select(this).datum({ startY: event.y, height });
                     })
@@ -513,6 +536,8 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleE.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
+                        const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
+                        if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const width = parseFloat(rect.attr('width') ?? '0');
                         d3.select(this).datum({ startX: event.x, width });
                     })
@@ -528,6 +553,8 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             handleW.call(
                 d3.drag<SVGCircleElement, unknown>()
                     .on('start', function (event: MouseEvent) {
+                        const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
+                        if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const x = parseFloat(rect.attr('x') ?? '0');
                         const width = parseFloat(rect.attr('width') ?? '0');
                         d3.select(this).datum({ startX: event.x, x, width });

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -349,8 +349,15 @@ function updateCropOverlay(element: Selection<any, any, any, any>) {
 }
 
 function startCrop(element: Selection<any, any, any, any>) {
-    const data = element.datum() as any;
-    const crop: CropValues = data.crop;
+    const data = element.datum() as any || {};
+    let crop: CropValues = data.crop;
+    if (!crop) {
+        const image = element.select('image');
+        const bbox = (image.node() as SVGGraphicsElement).getBBox();
+        crop = { x: 0, y: 0, width: bbox.width, height: bbox.height };
+        data.crop = crop;
+        element.datum(data);
+    }
     const overlay = element.select('.crop-controls');
     const rect = overlay.select('.crop-rect');
     rect
@@ -484,6 +491,11 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             );
 
             element.datum<any>({ ...(element.datum() || {}), crop: { x: 0, y: 0, width: bbox.width, height: bbox.height }, clipId });
+
+            element.on('dblclick.makeCroppable', (event: MouseEvent) => {
+                event.stopPropagation();
+                toggleCrop(element);
+            });
         });
 }
 

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -80,7 +80,7 @@ function applyTransform(element: Selection<any, any, any, any>, transform: Trans
 }
 
 export function makeDraggable(selection: Selection<any, any, any, any>) {
-    interface DragDatum { offsetX: number, offsetY: number, transform: TransformValues };
+    interface DragDatum { dragOffsetX: number, dragOffsetY: number, transform: TransformValues };
 
     selection.call(
         d3.drag()
@@ -90,22 +90,23 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
                 if (!overlay.empty() && overlay.style('display') !== 'none') {
                     finishCrop(element);
                 }
-                const data: any = element.datum();
+                const data: any = element.datum() || {};
                 const transform: TransformValues = data.transform ?? defaultTransform();
 
-                const offsetX = event.x - transform.translateX;
-                const offsetY = event.y - transform.translateY;
+                const dragOffsetX = event.x - transform.translateX;
+                const dragOffsetY = event.y - transform.translateY;
 
-                element.datum<DragDatum>({ offsetX, offsetY, transform });
+                element.datum<DragDatum>({ ...data, dragOffsetX, dragOffsetY, transform });
             })
             .on('drag', function (event: MouseEvent) {
                 const element = d3.select<any, DragDatum>(this);
-                const { offsetX, offsetY, transform } = element.datum();
+                const data = element.datum();
+                const { dragOffsetX, dragOffsetY, transform } = data;
 
                 const newTransform: TransformValues = {
                     ...transform,
-                    translateX: event.x - offsetX,
-                    translateY: event.y - offsetY,
+                    translateX: event.x - dragOffsetX,
+                    translateY: event.y - dragOffsetY,
                 };
 
                 applyTransform(element, newTransform);

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -499,17 +499,18 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             const handleN = overlay.select<SVGCircleElement>('.crop-handle-n');
             handleN.call(
                 d3.drag<SVGCircleElement, unknown>()
-                    .on('start', function (event: MouseEvent) {
+                    .on('start', function (event: any) {
                         const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
                         if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const y = parseFloat(rect.attr('y') ?? '0');
                         const height = parseFloat(rect.attr('height') ?? '0');
-                        d3.select(this).datum({ startY: event.y, y, height });
+                        (this as any).__drag = { y, height };
                     })
-                    .on('drag', function (event: MouseEvent) {
-                        const data = d3.select<any, any>(this).datum();
-                        let newY = Math.min(data.y + data.height - 1, event.y);
-                        let newHeight = data.height + (data.y - newY);
+                    .on('drag', function (event: any) {
+                        const drag = (this as any).__drag;
+                        if (!drag) return;
+                        let newY = Math.min(drag.y + drag.height - 1, event.y);
+                        let newHeight = drag.height + (drag.y - newY);
                         rect.attr('y', newY).attr('height', newHeight);
                         updateCropOverlay(element);
                     })
@@ -518,15 +519,16 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             const handleS = overlay.select<SVGCircleElement>('.crop-handle-s');
             handleS.call(
                 d3.drag<SVGCircleElement, unknown>()
-                    .on('start', function (event: MouseEvent) {
+                    .on('start', function (event: any) {
                         const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
                         if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const height = parseFloat(rect.attr('height') ?? '0');
-                        d3.select(this).datum({ startY: event.y, height });
+                        (this as any).__drag = { startY: event.y, height };
                     })
-                    .on('drag', function (event: MouseEvent) {
-                        const data = d3.select<any, any>(this).datum();
-                        let newHeight = Math.max(1, data.height + event.y - data.startY);
+                    .on('drag', function (event: any) {
+                        const drag = (this as any).__drag;
+                        if (!drag) return;
+                        let newHeight = Math.max(1, drag.height + event.y - drag.startY);
                         rect.attr('height', newHeight);
                         updateCropOverlay(element);
                     })
@@ -535,15 +537,16 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             const handleE = overlay.select<SVGCircleElement>('.crop-handle-e');
             handleE.call(
                 d3.drag<SVGCircleElement, unknown>()
-                    .on('start', function (event: MouseEvent) {
+                    .on('start', function (event: any) {
                         const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
                         if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const width = parseFloat(rect.attr('width') ?? '0');
-                        d3.select(this).datum({ startX: event.x, width });
+                        (this as any).__drag = { startX: event.x, width };
                     })
-                    .on('drag', function (event: MouseEvent) {
-                        const data = d3.select<any, any>(this).datum();
-                        let newWidth = Math.max(1, data.width + event.x - data.startX);
+                    .on('drag', function (event: any) {
+                        const drag = (this as any).__drag;
+                        if (!drag) return;
+                        let newWidth = Math.max(1, drag.width + event.x - drag.startX);
                         rect.attr('width', newWidth);
                         updateCropOverlay(element);
                     })
@@ -552,17 +555,18 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
             const handleW = overlay.select<SVGCircleElement>('.crop-handle-w');
             handleW.call(
                 d3.drag<SVGCircleElement, unknown>()
-                    .on('start', function (event: MouseEvent) {
+                    .on('start', function (event: any) {
                         const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
                         if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                         const x = parseFloat(rect.attr('x') ?? '0');
                         const width = parseFloat(rect.attr('width') ?? '0');
-                        d3.select(this).datum({ startX: event.x, x, width });
+                        (this as any).__drag = { startX: event.x, x, width };
                     })
-                    .on('drag', function (event: MouseEvent) {
-                        const data = d3.select<any, any>(this).datum();
-                        let newX = Math.min(data.x + data.width - 1, event.x);
-                        let newWidth = data.width + (data.x - newX);
+                    .on('drag', function (event: any) {
+                        const drag = (this as any).__drag;
+                        if (!drag) return;
+                        let newX = Math.min(drag.x + drag.width - 1, event.x);
+                        let newWidth = drag.width + (drag.x - newX);
                         rect.attr('x', newX).attr('width', newWidth);
                         updateCropOverlay(element);
                     })


### PR DESCRIPTION
## Summary
- enable cropping for images using `makeCroppable`
- hook cropping into the board UI
- style crop handles and overlay
- document the cropping hotkey and remove TODO entry

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856c1b868a4832e9606d8711ccdfe9b