### PR TITLE
Refactor board controls

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,15 @@
+## Instruction for Copilot, GPT, Codex and other LLM Agents
+
+* Remove items from the TODO lists when completing tasks.
+* Don't run `npm run lint`.
+
+## General Contributor Guidelines
+
+* Use concise commit messages describing the change.
+* Run `npm run build` to ensure the project compiles before committing.
+* Prefer TypeScript types where possible.
+* Keep dependencies pinned to the versions in `package.json`.
+* When adding features, update relevant documentation in `README.md`.
+* If tests are added, document how to run them in the PR description.
+* Ensure changes work on Node.js 20 and without network access.
+* Do not introduce new build tools or workflows without discussion.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ https://sergej-popov.github.io/tremolo/
 - **Delete** – remove the selected item.
 - **c** – crop selected image (or double-click an image to toggle cropping).
 
-## Instruction for Copilot, GPT, Codex and other LLM Agents
-* Remove items from TODO list when completing tasks.
-* Don't run linter.
-
 ## TODO general
 
 1. [Large] Provide undo and redo support for board changes.

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -303,7 +303,12 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
         });
 
         d3.select(window).on('click.makeResizable', (event: MouseEvent) => {
-            if (selectedElement && !selectedElement.node()?.contains(event.target as Node)) {
+            const controls = document.getElementById('board-controls');
+            if (
+                selectedElement &&
+                !selectedElement.node()?.contains(event.target as Node) &&
+                !(controls && controls.contains(event.target as Node))
+            ) {
                 clearSelection();
             }
         });


### PR DESCRIPTION
## Summary
- move control UI into a board-specific side panel
- keep board selected when using panel buttons
- reduce SVG to 100 x 100 pixels

## Testing
- `npm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6856e62dc434832ea162c4769dc14f39