### PR TITLE
Add color palette and zoom display

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://sergej-popov.github.io/tremolo/
 - Paste text to create sticky notes that can be dragged, resized and rotated. Double-click a sticky note to edit its text.
 - Select a pasted object and press **Delete** to remove it.
 - Quickly add predefined chords or scales or display all notes.
-- Choose sticky note colour from the palette in the header.
+- Choose sticky note colour from the palette in the header when a sticky note is selected.
 
 ## Hotkeys
 - **Delete** – remove the selected item.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://sergej-popov.github.io/tremolo/
 - Paste text to create sticky notes that can be dragged, resized and rotated. Double-click a sticky note to edit its text.
 - Select a pasted object and press **Delete** to remove it.
 - Quickly add predefined chords or scales or display all notes.
+- Choose sticky note colour from the palette in the header.
 
 ## Hotkeys
 - **Delete** – remove the selected item.

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import { AppBar, Toolbar, IconButton, Typography } from '@mui/material';
+import { AppBar, Toolbar, IconButton, Typography, Select, MenuItem, Box } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import { AppContext } from './Store';
+import { noteColors } from './theme';
 
 const Menu: React.FC = () => {
+  const app = useContext(AppContext);
+  const stickyColor = app?.stickyColor ?? noteColors[0];
+  const setStickyColor = app?.setStickyColor ?? (() => {});
 
   return (
     <AppBar position="static" style={{ marginBottom: "15px" }}>
@@ -23,6 +28,19 @@ const Menu: React.FC = () => {
         <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
           Tremolo
         </Typography>
+        <Box sx={{ mr: 2 }}>
+          <Select
+            size="small"
+            value={stickyColor}
+            onChange={(e) => setStickyColor(e.target.value as string)}
+          >
+            {noteColors.map((c) => (
+              <MenuItem value={c} key={c}>
+                <Box sx={{ width: 20, height: 20, backgroundColor: c }} />
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
         <IconButton target='_blank' href='https://github.com/Sergej-Popov/tremolo' >
           <GitHubIcon fontSize='large' />
         </IconButton>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -5,11 +5,13 @@ import MenuIcon from '@mui/icons-material/Menu';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
+import { updateSelectedColor } from './d3-ext';
 
 const Menu: React.FC = () => {
   const app = useContext(AppContext);
   const stickyColor = app?.stickyColor ?? noteColors[0];
   const setStickyColor = app?.setStickyColor ?? (() => {});
+  const stickySelected = app?.stickySelected ?? false;
 
   return (
     <AppBar position="static" style={{ marginBottom: "15px" }}>
@@ -28,19 +30,25 @@ const Menu: React.FC = () => {
         <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
           Tremolo
         </Typography>
-        <Box sx={{ mr: 2 }}>
-          <Select
-            size="small"
-            value={stickyColor}
-            onChange={(e) => setStickyColor(e.target.value as string)}
-          >
-            {noteColors.map((c) => (
-              <MenuItem value={c} key={c}>
-                <Box sx={{ width: 20, height: 20, backgroundColor: c }} />
-              </MenuItem>
-            ))}
-          </Select>
-        </Box>
+        {stickySelected && (
+          <Box id="sticky-color-select" sx={{ mr: 2 }}>
+            <Select
+              size="small"
+              value={stickyColor}
+              onChange={(e) => {
+                const color = e.target.value as string;
+                setStickyColor(color);
+                updateSelectedColor(color);
+              }}
+            >
+              {noteColors.map((c) => (
+                <MenuItem value={c} key={c}>
+                  <Box sx={{ width: 20, height: 20, backgroundColor: c }} />
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        )}
         <IconButton target='_blank' href='https://github.com/Sergej-Popov/tremolo' >
           <GitHubIcon fontSize='large' />
         </IconButton>

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -7,6 +7,8 @@ interface AppState {
   setData: React.Dispatch<React.SetStateAction<any[]>>;
   stickyColor: string;
   setStickyColor: React.Dispatch<React.SetStateAction<string>>;
+  stickySelected: boolean;
+  setStickySelected: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const AppContext = createContext<AppState | undefined>(undefined);
@@ -16,9 +18,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const [data, setData] = useState<any[]>([]);
   const [stickyColor, setStickyColor] = useState<string>(noteColors[0]);
+  const [stickySelected, setStickySelected] = useState<boolean>(false);
 
   return (
-    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor }}>
+    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor, stickySelected, setStickySelected }}>
       {children}
     </AppContext.Provider>
   );

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -1,8 +1,12 @@
 import React, { createContext, useState, ReactNode } from "react";
 
+import { noteColors } from "./theme";
+
 interface AppState {
   data: any[];
   setData: React.Dispatch<React.SetStateAction<any[]>>;
+  stickyColor: string;
+  setStickyColor: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const AppContext = createContext<AppState | undefined>(undefined);
@@ -11,9 +15,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
   const [data, setData] = useState<any[]>([]);
+  const [stickyColor, setStickyColor] = useState<string>(noteColors[0]);
 
   return (
-    <AppContext.Provider value={{ data, setData }}>
+    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor }}>
       {children}
     </AppContext.Provider>
   );

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -212,8 +212,7 @@ const GuitarBoard: React.FC = () => {
       .attr('y', 0)
       .attr('width', stickyWidth)
       .attr('height', stickyHeight)
-      .attr('fill', stickyColor)
-      .attr('stroke', 'black');
+      .attr('fill', stickyColor);
 
     const fo = group.append('foreignObject')
       .attr('x', 0)
@@ -228,7 +227,7 @@ const GuitarBoard: React.FC = () => {
       .style('height', '100%')
       .style('box-sizing', 'border-box')
       .style('font-family', 'Segoe UI')
-      .style('padding', '4px')
+      .style('padding', '8px')
       .style('overflow', 'hidden')
       .text(text);
 
@@ -359,8 +358,8 @@ const GuitarBoard: React.FC = () => {
         setStickySelected(d3.select(node).classed('sticky-note'));
       }
     };
-    window.addEventListener('selectionchange', handler);
-    return () => window.removeEventListener('selectionchange', handler);
+    window.addEventListener('stickyselectionchange', handler);
+    return () => window.removeEventListener('stickyselectionchange', handler);
   }, [setStickySelected]);
 
   useEffect(() => {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -130,7 +130,7 @@ let selectedElement: Selection<any, any, any, any> | null = null;
 let globalInit = false;
 
 function dispatchSelectionChange() {
-    window.dispatchEvent(new CustomEvent('selectionchange', { detail: selectedElement?.node() || null }));
+    window.dispatchEvent(new CustomEvent('stickyselectionchange', { detail: selectedElement?.node() || null }));
 }
 
 export function updateSelectedColor(color: string) {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -320,11 +320,14 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
         d3.select(window).on('click.makeResizable', (event: MouseEvent) => {
             const controls = document.getElementById('board-controls');
             const colorSelect = document.getElementById('sticky-color-select');
+            const target = event.target as Node;
+            const isSvg = target instanceof SVGElement;
             if (
                 selectedElement &&
-                !selectedElement.node()?.contains(event.target as Node) &&
-                !(controls && controls.contains(event.target as Node)) &&
-                !(colorSelect && colorSelect.contains(event.target as Node))
+                isSvg &&
+                !selectedElement.node()?.contains(target) &&
+                !(controls && controls.contains(target)) &&
+                !(colorSelect && colorSelect.contains(target))
             ) {
                 clearSelection();
             }

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -129,6 +129,20 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
 let selectedElement: Selection<any, any, any, any> | null = null;
 let globalInit = false;
 
+function dispatchSelectionChange() {
+    window.dispatchEvent(new CustomEvent('selectionchange', { detail: selectedElement?.node() || null }));
+}
+
+export function updateSelectedColor(color: string) {
+    if (selectedElement && selectedElement.classed('sticky-note')) {
+        selectedElement.select('rect').attr('fill', color);
+    }
+}
+
+export function isStickySelected(): boolean {
+    return !!selectedElement && selectedElement.classed('sticky-note');
+}
+
 interface ResizeOptions {
     lockAspectRatio?: boolean;
     rotatable?: boolean;
@@ -286,6 +300,7 @@ function clearSelection() {
     selectedElement.selectAll('.resize-handle').remove();
     selectedElement.selectAll('.rotate-handle').remove();
     selectedElement = null;
+    dispatchSelectionChange();
 }
 
 export function makeResizable(selection: Selection<any, any, any, any>, options: ResizeOptions = {}) {
@@ -304,10 +319,12 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
 
         d3.select(window).on('click.makeResizable', (event: MouseEvent) => {
             const controls = document.getElementById('board-controls');
+            const colorSelect = document.getElementById('sticky-color-select');
             if (
                 selectedElement &&
                 !selectedElement.node()?.contains(event.target as Node) &&
-                !(controls && controls.contains(event.target as Node))
+                !(controls && controls.contains(event.target as Node)) &&
+                !(colorSelect && colorSelect.contains(event.target as Node))
             ) {
                 clearSelection();
             }
@@ -332,6 +349,7 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
             if (options.rotatable) {
                 addRotateHandle(element);
             }
+            dispatchSelectionChange();
         });
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -8,4 +8,14 @@ const theme = createTheme({
     },
 });
 
+export const noteColors = [
+    "#8CB369",
+    "#F4E285",
+    "#F4A259",
+    "#5B8E7D",
+    "#BC4B51",
+    "#168AAD",
+    "#FF9B85",
+];
+
 export default theme;


### PR DESCRIPTION
## Summary
- increase guitar board height and enlarge video embeds
- expose note color palette and state handling
- allow sticky note colour selection in header
- show zoom level with reset control
- update docs for sticky note colour feature

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6856f188cf34832eb9b5957840544be5