### PR TITLE
Implement grid snapping and axis locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://sergej-popov.github.io/tremolo/
 
 ## Features
 - Drag and resize the guitar board.
-- Hold **Ctrl** while dragging to snap elements to a 10 px grid. A faint grid appears while snapping. Hold **Shift** to constrain movement to one axis. Rotating with **Ctrl** snaps to 15° steps.
+- Hold **Ctrl** while dragging to snap elements to a 10 px grid. A grid overlay appears while snapping or in debug mode. Hold **Shift** to constrain movement to one axis. Rotating with **Ctrl** snaps to 15° steps.
 - Add multiple guitar boards in the same workspace.
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ https://sergej-popov.github.io/tremolo/
 
 ## Features
 - Drag and resize the guitar board.
+- Hold **Ctrl** while dragging to snap elements to a 10 px grid. Hold **Shift** to constrain movement to a single axis. Rotating with **Ctrl** snaps to 15° steps.
 - Add multiple guitar boards in the same workspace.
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.
@@ -32,13 +33,12 @@ https://sergej-popov.github.io/tremolo/
 ## TODO general
 
 1. [Large] Provide undo and redo support for board changes.
-2. Allow items to snap to a grid for precise alignment.
-3. Drawing pen tool
-4. Connectiing lines
-5. Add a dark and light theme toggle for the fretboard interface.
-6. Draw style themes
-7. Tool pannel
-8. Contextual menu panel
+2. Drawing pen tool
+3. Connectiing lines
+4. Add a dark and light theme toggle for the fretboard interface.
+5. Draw style themes
+6. Tool pannel
+7. Contextual menu panel
 
 ## TODO collaboration
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://sergej-popov.github.io/tremolo/
 
 ## Features
 - Drag and resize the guitar board.
-- Hold **Ctrl** while dragging to snap elements to a 10 px grid. Hold **Shift** to constrain movement to a single axis. Rotating with **Ctrl** snaps to 15° steps.
+- Hold **Ctrl** while dragging to snap elements to a 10 px grid. A faint grid appears while snapping. Hold **Shift** to constrain movement to one axis. Rotating with **Ctrl** snaps to 15° steps.
 - Add multiple guitar boards in the same workspace.
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.

--- a/src/App.css
+++ b/src/App.css
@@ -99,6 +99,11 @@
 .component-debug-cross {
     fill: red;
 }
+
+.grid-overlay {
+    pointer-events: none;
+    opacity: 0.4;
+}
 #root, html, body {
     height: 100%;
     margin: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -102,7 +102,7 @@
 
 .grid-overlay {
     pointer-events: none;
-    opacity: 0.4;
+    opacity: 1;
 }
 #root, html, body {
     height: 100%;

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -636,6 +636,7 @@ const GuitarBoard: React.FC = () => {
       }
     }
     workspaceRef.current = workspace.node();
+    setSvgRoot(svgRef.current, workspaceRef.current);
 
     boards.forEach((id) => {
       let b = workspace.select<SVGGElement>(`.guitar-board-${id}`);
@@ -691,7 +692,13 @@ const GuitarBoard: React.FC = () => {
   useEffect(() => {
     const svg = d3.select(svgRef.current);
     const zoom = d3.zoom<SVGSVGElement, unknown>()
-      .filter(event => event.type !== 'dblclick')
+      .filter(event => {
+        if (event.type === 'dblclick') return false;
+        const e = event as any;
+        if (e.ctrlKey) return false;
+        const target = e.target as Element;
+        return target === svgRef.current || target === workspaceRef.current;
+      })
       .scaleExtent([0.1, 10])
       .on('start', hideTooltip)
       .on('zoom', (event) => {
@@ -704,7 +711,7 @@ const GuitarBoard: React.FC = () => {
     svg.call(zoom as any);
     zoomBehaviorRef.current = zoom;
     setZoomTransform(d3.zoomIdentity);
-    setSvgRoot(svgRef.current);
+    setSvgRoot(svgRef.current, workspaceRef.current);
   }, []);
 
   useEffect(() => {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -239,6 +239,8 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
     selection.call(
         d3.drag()
             .on('start', function (event: MouseEvent) {
+                const stopProp = (event as any).sourceEvent?.stopPropagation || (event as any).stopPropagation;
+                if (typeof stopProp === 'function') stopProp.call(event.sourceEvent ?? event);
                 const element = d3.select(this);
                 const overlay = element.select('.crop-controls');
                 if (!overlay.empty() && overlay.style('display') !== 'none') {
@@ -537,7 +539,6 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
                     const ctrl = (event as any).sourceEvent?.ctrlKey;
                     if (ctrl) {
                         angle = Math.round(angle / 15) * 15;
-                        data.cumulative = angle * Math.PI / 180;
                     }
 
                     const newTransform: TransformValues = { ...transform, rotate: angle };


### PR DESCRIPTION
## Summary
- add grid overlay and snapping when holding Ctrl
- allow shift-dragging to lock axis
- snap rotation angles to 15° with Ctrl
- document snapping and remove TODO item

## Testing
- `npx --offline tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68581ff18168832eb25e74c7f135dadb