### PR TITLE
Add brush drawing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://sergej-popov.github.io/tremolo/
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.
 - Pasting text always inserts plain text. When editing a sticky note the paste goes into the note instead of creating a new one.
 - Select a pasted object and press **Delete** to remove it.
+- Use the brush tool to draw smooth, pressure-sensitive strokes that can be moved, resized and rotated.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.
@@ -33,12 +34,11 @@ https://sergej-popov.github.io/tremolo/
 ## TODO general
 
 1. [Large] Provide undo and redo support for board changes.
-2. Drawing pen tool
-3. Connectiing lines
-4. Add a dark and light theme toggle for the fretboard interface.
-5. Draw style themes
-6. Tool pannel
-7. Contextual menu panel
+2. Connectiing lines
+3. Add a dark and light theme toggle for the fretboard interface.
+4. Draw style themes
+5. Tool pannel
+6. Contextual menu panel
 
 ## TODO collaboration
 

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -11,6 +11,7 @@ import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize } 
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
+import BrushIcon from '@mui/icons-material/Brush';
 
 const Menu: React.FC = () => {
   const app = useContext(AppContext);
@@ -20,6 +21,8 @@ const Menu: React.FC = () => {
   const setStickyAlign = app?.setStickyAlign ?? (() => {});
   const stickySelected = app?.stickySelected ?? false;
   const addBoard = app?.addBoard ?? (() => {});
+  const drawingMode = app?.drawingMode ?? false;
+  const setDrawingMode = app?.setDrawingMode ?? (() => {});
   const [fontSize, setFontSize] = React.useState<string>('auto');
 
   React.useEffect(() => {
@@ -117,6 +120,9 @@ const Menu: React.FC = () => {
             </Box>
           </>
         )}
+        <IconButton color={drawingMode ? 'secondary' : 'inherit'} onClick={() => setDrawingMode(!drawingMode)} sx={{ mr: 1 }}>
+          <BrushIcon />
+        </IconButton>
         <IconButton target='_blank' href='https://github.com/Sergej-Popov/tremolo' >
           <GitHubIcon fontSize='large' />
         </IconButton>

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -16,6 +16,8 @@ interface AppState {
   addBoard: () => void;
   debug: boolean;
   setDebug: React.Dispatch<React.SetStateAction<boolean>>;
+  drawingMode: boolean;
+  setDrawingMode: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const AppContext = createContext<AppState | undefined>(undefined);
@@ -29,6 +31,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [stickySelected, setStickySelected] = useState<boolean>(false);
   const [boards, setBoards] = useState<number[]>([0]);
   const [debug, setDebug] = useState<boolean>(false);
+  const [drawingMode, setDrawingMode] = useState<boolean>(false);
 
   const addBoard = () => {
     setBoards((ids) => [...ids, ids.length ? Math.max(...ids) + 1 : 0]);
@@ -49,7 +52,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   }, [debug]);
 
   return (
-    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor, stickyAlign, setStickyAlign, stickySelected, setStickySelected, boards, addBoard, debug, setDebug }}>
+    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor, stickyAlign, setStickyAlign, stickySelected, setStickySelected, boards, addBoard, debug, setDebug, drawingMode, setDrawingMode }}>
       {children}
     </AppContext.Provider>
   );

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -333,7 +333,7 @@ export function updateSelectedFontSize(size: number | 'auto') {
 }
 
 export interface ElementCopy {
-    type: 'image' | 'video' | 'sticky' | 'board';
+    type: 'image' | 'video' | 'sticky' | 'board' | 'drawing';
     data: any;
 }
 
@@ -344,6 +344,7 @@ export function getSelectedElementData(): ElementCopy | null {
     else if (selectedElement.classed('embedded-video')) type = 'video';
     else if (selectedElement.classed('sticky-note')) type = 'sticky';
     else if (selectedElement.classed('guitar-board')) type = 'board';
+    else if (selectedElement.classed('drawing')) type = 'drawing';
     if (!type) return null;
     const data = { ...(selectedElement.datum() as any) };
     if (type === 'board') {


### PR DESCRIPTION
## Summary
- add brush icon to menu to toggle drawing mode
- store drawing mode in context
- implement pressure-sensitive brush strokes as draggable objects
- support copying drawing elements
- document brush feature and update TODO list

## Testing
- `npx tsc --noEmit` *(fails: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685825de4834832e95656ac467287142