### PR TITLE
Add in-app shortcut help

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,21 @@ https://sergej-popov.github.io/tremolo/
 - Press **/** or **?** or use the floating question icon to see a help dialog with all shortcuts.
 
 ## Hotkeys
+
+### General
 - **Delete** – remove the selected item.
-- **c** – crop selected image (or double-click an image to toggle cropping).
 - **Ctrl+C** – copy selected element to the clipboard.
 - **Ctrl+V** – paste copied element at the cursor location.
 - **Ctrl+D** – duplicate the selected element at the cursor.
-- **b** – toggle the brush drawing mode.
+- **r** – reset element rotation.
 - **/** or **?** – open the help dialog.
+
+### Tools
+- **b** – toggle the brush drawing mode.
+- **e** – toggle the code mode.
+
+### Images
+- **c** – crop selected image (or double-click an image to toggle cropping).
 
 ## TODO general
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ https://sergej-popov.github.io/tremolo/
 - Set a fixed font size for a sticky note from the header dropdown or choose "Auto" for automatic sizing (6–48px in even steps).
 - When brush mode is active a dropdown sets stroke thickness, or choose "Auto" for pressure-based width.
 - Toggle debug mode with **d** to show extra info, crosses over elements, and a debug panel with coordinates and rotation angles.
-- Press **/** or **?** or use the floating question button to see a help dialog with all shortcuts.
+- Press **/** or **?** or use the floating question icon to see a help dialog with all shortcuts.
 
 ## Hotkeys
 - **Delete** – remove the selected item.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ https://sergej-popov.github.io/tremolo/
 - Set a fixed font size for a sticky note from the header dropdown or choose "Auto" for automatic sizing (6–48px in even steps).
 - When brush mode is active a dropdown sets stroke thickness, or choose "Auto" for pressure-based width.
 - Toggle debug mode with **d** to show extra info, crosses over elements, and a debug panel with coordinates and rotation angles.
+- Press **/** or **?** or use the floating question button to see a help dialog with all shortcuts.
 
 ## Hotkeys
 - **Delete** – remove the selected item.
@@ -32,6 +33,7 @@ https://sergej-popov.github.io/tremolo/
 - **Ctrl+V** – paste copied element at the cursor location.
 - **Ctrl+D** – duplicate the selected element at the cursor.
 - **b** – toggle the brush drawing mode.
+- **/** or **?** – open the help dialog.
 
 ## TODO general
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { Box, CssBaseline, ThemeProvider } from "@mui/material";
 
+import HelpDialog from "./HelpDialog";
+
 
 import MainPage from "./pages/MainPage";
 import SecondPage from "./pages/SecondPage";
@@ -29,6 +31,7 @@ function App() {
                 <Route path="/" element={<MainPage />} />
                 <Route path="/second" element={<SecondPage />} />
               </Routes>
+              <HelpDialog />
             </Box>
           </Router>
         </AppProvider>

--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -2,16 +2,33 @@ import React from 'react';
 import { Dialog, DialogTitle, DialogContent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, IconButton } from '@mui/material';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
-const shortcuts = [
-  { key: 'Delete', action: 'Remove the selected item' },
-  { key: 'c', action: 'Crop selected image' },
-  { key: 'Ctrl+C', action: 'Copy selected element' },
-  { key: 'Ctrl+V', action: 'Paste copied element at cursor' },
-  { key: 'Ctrl+D', action: 'Duplicate the selected element' },
-  { key: 'b', action: 'Toggle brush drawing mode' },
-  { key: 'd', action: 'Toggle debug mode' },
-  { key: 'r', action: 'Reset element rotation' },
-  { key: '/ or ?', action: 'Open this help dialog' },
+interface ShortcutItem { key: string; action: string }
+
+interface ShortcutSection { title: string; items: ShortcutItem[] }
+
+const shortcuts: ShortcutSection[] = [
+  {
+    title: 'General',
+    items: [
+      { key: 'Delete', action: 'Remove the selected item' },
+      { key: 'Ctrl+C', action: 'Copy selected element' },
+      { key: 'Ctrl+V', action: 'Paste copied element at cursor' },
+      { key: 'Ctrl+D', action: 'Duplicate the selected element' },
+      { key: 'r', action: 'Reset element rotation' },
+      { key: '/ or ?', action: 'Open this help dialog' },
+    ],
+  },
+  {
+    title: 'Tools',
+    items: [
+      { key: 'b', action: 'Toggle brush drawing mode' },
+      { key: 'e', action: 'Toggle code mode' },
+    ],
+  },
+  {
+    title: 'Images',
+    items: [{ key: 'c', action: 'Crop selected image' }],
+  },
 ];
 
 const HelpDialog: React.FC = () => {
@@ -52,11 +69,20 @@ const HelpDialog: React.FC = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {shortcuts.map((s) => (
-                  <TableRow key={s.key}>
-                    <TableCell>{s.key}</TableCell>
-                    <TableCell>{s.action}</TableCell>
-                  </TableRow>
+                {shortcuts.map((section) => (
+                  <React.Fragment key={section.title}>
+                    <TableRow>
+                      <TableCell colSpan={2} sx={{ fontWeight: 'bold' }}>
+                        {section.title}
+                      </TableCell>
+                    </TableRow>
+                    {section.items.map((i) => (
+                      <TableRow key={i.key}>
+                        <TableCell>{i.key}</TableCell>
+                        <TableCell>{i.action}</TableCell>
+                      </TableRow>
+                    ))}
+                  </React.Fragment>
                 ))}
               </TableBody>
             </Table>

--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dialog, DialogTitle, DialogContent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Fab } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, IconButton } from '@mui/material';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
 const shortcuts = [
@@ -37,9 +37,9 @@ const HelpDialog: React.FC = () => {
 
   return (
     <>
-      <Fab aria-label="help" onClick={handleOpen} sx={{ position: 'fixed', bottom: 16, right: 16 }}>
-        <HelpOutlineIcon />
-      </Fab>
+      <IconButton aria-label="help" onClick={handleOpen} sx={{ position: 'fixed', bottom: 16, right: 16 }}>
+        <HelpOutlineIcon fontSize="small" />
+      </IconButton>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>Keyboard Shortcuts</DialogTitle>
         <DialogContent>

--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Fab } from '@mui/material';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+
+const shortcuts = [
+  { key: 'Delete', action: 'Remove the selected item' },
+  { key: 'c', action: 'Crop selected image' },
+  { key: 'Ctrl+C', action: 'Copy selected element' },
+  { key: 'Ctrl+V', action: 'Paste copied element at cursor' },
+  { key: 'Ctrl+D', action: 'Duplicate the selected element' },
+  { key: 'b', action: 'Toggle brush drawing mode' },
+  { key: 'd', action: 'Toggle debug mode' },
+  { key: 'r', action: 'Reset element rotation' },
+  { key: '/ or ?', action: 'Open this help dialog' },
+];
+
+const HelpDialog: React.FC = () => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.getAttribute('contenteditable') === 'true')) {
+        return;
+      }
+      if (e.key === '/' || e.key === '?') {
+        setOpen(true);
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <>
+      <Fab aria-label="help" onClick={handleOpen} sx={{ position: 'fixed', bottom: 16, right: 16 }}>
+        <HelpOutlineIcon />
+      </Fab>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Keyboard Shortcuts</DialogTitle>
+        <DialogContent>
+          <TableContainer component={Paper}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Shortcut</TableCell>
+                  <TableCell>Action</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {shortcuts.map((s) => (
+                  <TableRow key={s.key}>
+                    <TableCell>{s.key}</TableCell>
+                    <TableCell>{s.action}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default HelpDialog;


### PR DESCRIPTION
## Summary
- add a HelpDialog with a shortcut table and floating question button
- show HelpDialog from the app root
- document new help popup and hotkey in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68582d176f38832eab30886618e158fd