### PR TITLE
Add code block feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://sergej-popov.github.io/tremolo/
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.
 - Paste text to create sticky notes that can be dragged, resized and rotated. Double-click a sticky note to edit its text.
+- Add code blocks with syntax highlighting using the </> button or **c** shortcut.
 - Sticky note text wraps and shrinks automatically; if it still overflows at the minimum size, a thin scrollbar appears.
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.
 - Pasting text always inserts plain text. When editing a sticky note the paste goes into the note instead of creating a new one.

--- a/index.html
+++ b/index.html
@@ -6,10 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     
     <link href="https://fonts.cdnfonts.com/css/segoe-ui-4" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
     <title>Tremolo</title>
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,16 @@
     caret-color: black; /* Ensure the cursor is visible */
 }
 
+.code-block code {
+    outline: none;
+    display: block;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    font-family: monospace;
+    white-space: pre;
+}
+
 .crop-controls {
     pointer-events: none;
 }

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -5,9 +5,10 @@ import { AppBar, Toolbar, IconButton, Typography, Select, MenuItem, Box, ToggleB
 import MenuIcon from '@mui/icons-material/Menu';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
+import CodeIcon from '@mui/icons-material/Code';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedLanguage } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
@@ -20,12 +21,14 @@ const Menu: React.FC = () => {
   const stickyAlign = app?.stickyAlign ?? 'center';
   const setStickyAlign = app?.setStickyAlign ?? (() => {});
   const stickySelected = app?.stickySelected ?? false;
+  const codeSelected = app?.codeSelected ?? false;
   const addBoard = app?.addBoard ?? (() => {});
   const drawingMode = app?.drawingMode ?? false;
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
   const brushWidth = app?.brushWidth ?? 'auto';
   const setBrushWidth = app?.setBrushWidth ?? (() => {});
   const [fontSize, setFontSize] = React.useState<string>('auto');
+  const [codeLang, setCodeLang] = React.useState<string>('javascript');
 
   React.useEffect(() => {
     const handler = (e: any) => {
@@ -33,8 +36,12 @@ const Menu: React.FC = () => {
       if (el && d3.select(el).classed('sticky-note')) {
         const data = d3.select(el).datum() as any;
         setFontSize(data.fontSize != null ? data.fontSize.toString() : 'auto');
+      } else if (el && d3.select(el).classed('code-block')) {
+        const data = d3.select(el).datum() as any;
+        setCodeLang(data.language || 'javascript');
       } else {
         setFontSize('auto');
+        setCodeLang('javascript');
       }
     };
     window.addEventListener('stickyselectionchange', handler as EventListener);
@@ -121,6 +128,28 @@ const Menu: React.FC = () => {
               </Select>
             </Box>
           </>
+        )}
+        <IconButton color="inherit" sx={{ mr: 1 }} onClick={() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))}>
+          <CodeIcon />
+        </IconButton>
+        {codeSelected && (
+          <Box id="code-lang-select" sx={{ mr: 2 }}>
+            <Select
+              size="small"
+              value={codeLang}
+              onChange={(e) => {
+                const lang = e.target.value as string;
+                setCodeLang(lang);
+                updateSelectedLanguage(lang);
+              }}
+            >
+              <MenuItem value="javascript">JavaScript</MenuItem>
+              <MenuItem value="python">Python</MenuItem>
+              <MenuItem value="java">Java</MenuItem>
+              <MenuItem value="cpp">C++</MenuItem>
+              <MenuItem value="plaintext">Plain Text</MenuItem>
+            </Select>
+          </Box>
         )}
         <IconButton color={drawingMode ? 'secondary' : 'inherit'} onClick={() => setDrawingMode(!drawingMode)} sx={{ mr: 1 }}>
           <BrushIcon />

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -12,6 +12,8 @@ interface AppState {
   setStickyAlign: React.Dispatch<React.SetStateAction<'left' | 'center' | 'right'>>;
   stickySelected: boolean;
   setStickySelected: React.Dispatch<React.SetStateAction<boolean>>;
+  codeSelected: boolean;
+  setCodeSelected: React.Dispatch<React.SetStateAction<boolean>>;
   boards: number[];
   addBoard: () => void;
   debug: boolean;
@@ -31,6 +33,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [stickyColor, setStickyColor] = useState<string>(noteColors[0]);
   const [stickyAlign, setStickyAlign] = useState<'left' | 'center' | 'right'>('center');
   const [stickySelected, setStickySelected] = useState<boolean>(false);
+  const [codeSelected, setCodeSelected] = useState<boolean>(false);
   const [boards, setBoards] = useState<number[]>([0]);
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
@@ -58,7 +61,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   }, [debug]);
 
   return (
-    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor, stickyAlign, setStickyAlign, stickySelected, setStickySelected, boards, addBoard, debug, setDebug, drawingMode, setDrawingMode, brushWidth, setBrushWidth }}>
+    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor, stickyAlign, setStickyAlign, stickySelected, setStickySelected, codeSelected, setCodeSelected, boards, addBoard, debug, setDebug, drawingMode, setDrawingMode, brushWidth, setBrushWidth }}>
       {children}
     </AppContext.Provider>
   );

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -332,8 +332,20 @@ export function updateSelectedFontSize(size: number | 'auto') {
     }
 }
 
+export function updateSelectedLanguage(lang: string) {
+    if (selectedElement && selectedElement.classed('code-block')) {
+        const code = selectedElement.select<HTMLElement>('foreignObject > pre > code');
+        code.attr('class', lang);
+        const data = selectedElement.datum() as any;
+        data.language = lang;
+        if ((window as any).hljs) {
+            (window as any).hljs.highlightElement(code.node());
+        }
+    }
+}
+
 export interface ElementCopy {
-    type: 'image' | 'video' | 'sticky' | 'board' | 'drawing';
+    type: 'image' | 'video' | 'sticky' | 'board' | 'drawing' | 'code';
     data: any;
 }
 
@@ -345,6 +357,7 @@ export function getSelectedElementData(): ElementCopy | null {
     else if (selectedElement.classed('sticky-note')) type = 'sticky';
     else if (selectedElement.classed('guitar-board')) type = 'board';
     else if (selectedElement.classed('drawing')) type = 'drawing';
+    else if (selectedElement.classed('code-block')) type = 'code';
     if (!type) return null;
     const data = { ...(selectedElement.datum() as any) };
     if (type === 'board') {
@@ -355,6 +368,10 @@ export function getSelectedElementData(): ElementCopy | null {
 
 export function isStickySelected(): boolean {
     return !!selectedElement && selectedElement.classed('sticky-note');
+}
+
+export function isCroppableSelected(): boolean {
+    return !!selectedElement && selectedElement.classed('croppable');
 }
 
 interface ResizeOptions {


### PR DESCRIPTION
## Summary
- add code block insertion with syntax highlighting
- support code language dropdown and keyboard shortcut
- expose selected element APIs and update UI
- document code block usage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68582db0334c832ea4ea9a45f691d018