### PR TITLE
Add Shiki code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://sergej-popov.github.io/tremolo/
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.
 - Pasting text always inserts plain text. When editing a sticky note the paste goes into the note instead of creating a new one.
 - Select a pasted object and press **Delete** to remove it.
-- Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size.
+- Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme, font size and line numbers. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://sergej-popov.github.io/tremolo/
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.
 - Pasting text always inserts plain text. When editing a sticky note the paste goes into the note instead of creating a new one.
 - Select a pasted object and press **Delete** to remove it.
+- Insert code blocks with syntax highlighting. When a code block is selected a dropdown in the header changes its language.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ https://sergej-popov.github.io/tremolo/
 - Add multiple guitar boards in the same workspace.
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.
-- Paste text to create sticky notes that can be dragged, resized and rotated. Double-click a sticky note to edit its text.
+- Paste text to create sticky notes that can be dragged, resized and rotated. Double-click a sticky note to edit its text, or press **n** or use the toolbar button to insert an empty note.
 - Sticky note text wraps and shrinks automatically; if it still overflows at the minimum size, a thin scrollbar appears.
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.
 - Pasting text always inserts plain text. When editing a sticky note the paste goes into the note instead of creating a new one.
 - Select a pasted object and press **Delete** to remove it.
-- Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme, font size and line numbers. Only GitHub light and dark themes are available.
+- Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
@@ -39,6 +39,7 @@ https://sergej-popov.github.io/tremolo/
 
 ### Tools
 - **b** – toggle the brush drawing mode.
+- **n** – insert a sticky note.
 - **c** – insert a code block.
 
 ### Images

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://sergej-popov.github.io/tremolo/
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.
 - Pasting text always inserts plain text. When editing a sticky note the paste goes into the note instead of creating a new one.
 - Select a pasted object and press **Delete** to remove it.
-- Insert code blocks with syntax highlighting. When a code block is selected a dropdown in the header changes its language.
+- Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language and theme.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ https://sergej-popov.github.io/tremolo/
 
 ### Tools
 - **b** – toggle the brush drawing mode.
-- **e** – toggle the code mode.
+- **c** – insert a code block.
 
 ### Images
 - **c** – crop selected image (or double-click an image to toggle cropping).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://sergej-popov.github.io/tremolo/
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.
 - Pasting text always inserts plain text. When editing a sticky note the paste goes into the note instead of creating a new one.
 - Select a pasted object and press **Delete** to remove it.
-- Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language and theme.
+- Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
-    "rollup": "^4.24.0"
+    "rollup": "^4.24.0",
+    "shiki": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/src/App.css
+++ b/src/App.css
@@ -42,7 +42,7 @@
 }
 
 .sticky-text.scrollable::-webkit-scrollbar {
-    width: 4px;
+    width: 3px;
 }
 
 .sticky-text.scrollable::-webkit-scrollbar-thumb {
@@ -62,12 +62,41 @@
 
 .code-block pre {
     font-size: 14px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
 }
 
 .code-block pre.edit-mode {
     user-select: text;
     pointer-events: all;
     caret-color: black;
+}
+
+.code-block pre::-webkit-scrollbar {
+    width: 3px;
+    height: 3px;
+}
+
+.code-block pre::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-radius: 2px;
+}
+
+.code-block pre::-webkit-scrollbar-track {
+    background-color: transparent;
+}
+
+.code-block .code-line {
+    display: block;
+}
+
+.code-block .line-number {
+    display: inline-block;
+    width: 2em;
+    margin-right: 6px;
+    text-align: right;
+    user-select: none;
+    color: gray;
 }
 
 .crop-controls {

--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,10 @@
     caret-color: black; /* Ensure the cursor is visible */
 }
 
+.code-block pre {
+    font-size: 14px;
+}
+
 .code-block pre.edit-mode {
     user-select: text;
     pointer-events: all;

--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,12 @@
     caret-color: black; /* Ensure the cursor is visible */
 }
 
+.code-block pre.edit-mode {
+    user-select: text;
+    pointer-events: all;
+    caret-color: black;
+}
+
 .crop-controls {
     pointer-events: none;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -86,18 +86,6 @@
     background-color: transparent;
 }
 
-.code-block .code-line {
-    display: block;
-}
-
-.code-block .line-number {
-    display: inline-block;
-    width: 2em;
-    margin-right: 6px;
-    text-align: right;
-    user-select: none;
-    color: gray;
-}
 
 .crop-controls {
     pointer-events: none;

--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -22,6 +22,7 @@ const shortcuts: ShortcutSection[] = [
     title: 'Tools',
     items: [
       { key: 'b', action: 'Toggle brush drawing mode' },
+      { key: 'n', action: 'Insert sticky note' },
       { key: 'c', action: 'Insert code block' },
     ],
   },

--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -22,7 +22,7 @@ const shortcuts: ShortcutSection[] = [
     title: 'Tools',
     items: [
       { key: 'b', action: 'Toggle brush drawing mode' },
-      { key: 'e', action: 'Toggle code mode' },
+      { key: 'c', action: 'Insert code block' },
     ],
   },
   {

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,13 +7,13 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedCodeLineNumbers, highlightLangs, highlightThemes } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import BrushIcon from '@mui/icons-material/Brush';
 import CodeIcon from '@mui/icons-material/Code';
-import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
+import StickyNote2Icon from '@mui/icons-material/StickyNote2';
 const codeLanguages = highlightLangs as readonly string[];
 const codeThemes = highlightThemes as readonly string[];
 
@@ -31,8 +31,6 @@ const Menu: React.FC = () => {
   const setCodeTheme = app?.setCodeTheme ?? (() => {});
   const codeFontSize = app?.codeFontSize ?? 14;
   const setCodeFontSize = app?.setCodeFontSize ?? (() => {});
-  const codeLineNumbers = app?.codeLineNumbers ?? false;
-  const setCodeLineNumbers = app?.setCodeLineNumbers ?? (() => {});
   const addBoard = app?.addBoard ?? (() => {});
   const drawingMode = app?.drawingMode ?? false;
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
@@ -52,7 +50,6 @@ const Menu: React.FC = () => {
       }
       if (!el || !d3.select(el).classed('code-block')) {
         setCodeSize(codeFontSize);
-        setCodeLineNumbers(codeLineNumbers);
       }
       if (el && d3.select(el).classed('code-block')) {
         const data = d3.select(el).datum() as any;
@@ -60,7 +57,6 @@ const Menu: React.FC = () => {
         setCodeTheme(data.theme ?? 'github-dark');
         setCodeFontSize(data.fontSize ?? codeFontSize);
         setCodeSize(data.fontSize ?? codeFontSize);
-        setCodeLineNumbers(!!data.lineNumbers);
       }
     };
     window.addEventListener('stickyselectionchange', handler as EventListener);
@@ -151,6 +147,9 @@ const Menu: React.FC = () => {
         <IconButton color={drawingMode ? 'secondary' : 'inherit'} onClick={() => setDrawingMode(!drawingMode)} sx={{ mr: 1 }}>
           <BrushIcon />
         </IconButton>
+        <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createsticky'))} sx={{ mr: 1 }}>
+          <StickyNote2Icon />
+        </IconButton>
         <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
           <CodeIcon />
         </IconButton>
@@ -202,13 +201,6 @@ const Menu: React.FC = () => {
                 ))}
               </Select>
             </Box>
-            <IconButton color={codeLineNumbers ? 'secondary' : 'inherit'} onClick={() => {
-              const val = !codeLineNumbers;
-              setCodeLineNumbers(val);
-              updateSelectedCodeLineNumbers(val);
-            }} sx={{ mr: 1 }}>
-              <FormatListNumberedIcon />
-            </IconButton>
           </>
         )}
         {drawingMode && (

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,11 +7,13 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, highlightLangs, highlightThemes } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedCodeLineNumbers, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import BrushIcon from '@mui/icons-material/Brush';
+import CodeIcon from '@mui/icons-material/Code';
+import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
 const codeLanguages = highlightLangs as readonly string[];
 const codeThemes = highlightThemes as readonly string[];
 
@@ -25,10 +27,12 @@ const Menu: React.FC = () => {
   const codeSelected = app?.codeSelected ?? false;
   const codeLanguage = app?.codeLanguage ?? 'typescript';
   const setCodeLanguage = app?.setCodeLanguage ?? (() => {});
-  const codeTheme = app?.codeTheme ?? 'nord';
+  const codeTheme = app?.codeTheme ?? 'github-dark';
   const setCodeTheme = app?.setCodeTheme ?? (() => {});
   const codeFontSize = app?.codeFontSize ?? 14;
   const setCodeFontSize = app?.setCodeFontSize ?? (() => {});
+  const codeLineNumbers = app?.codeLineNumbers ?? false;
+  const setCodeLineNumbers = app?.setCodeLineNumbers ?? (() => {});
   const addBoard = app?.addBoard ?? (() => {});
   const drawingMode = app?.drawingMode ?? false;
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
@@ -48,13 +52,15 @@ const Menu: React.FC = () => {
       }
       if (!el || !d3.select(el).classed('code-block')) {
         setCodeSize(codeFontSize);
+        setCodeLineNumbers(codeLineNumbers);
       }
       if (el && d3.select(el).classed('code-block')) {
         const data = d3.select(el).datum() as any;
         setCodeLanguage(data.lang ?? 'typescript');
-        setCodeTheme(data.theme ?? 'nord');
+        setCodeTheme(data.theme ?? 'github-dark');
         setCodeFontSize(data.fontSize ?? codeFontSize);
         setCodeSize(data.fontSize ?? codeFontSize);
+        setCodeLineNumbers(!!data.lineNumbers);
       }
     };
     window.addEventListener('stickyselectionchange', handler as EventListener);
@@ -146,7 +152,7 @@ const Menu: React.FC = () => {
           <BrushIcon />
         </IconButton>
         <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
-          <Box component="span" sx={{ fontFamily: 'monospace', fontWeight: 'bold' }}>&lt;/&gt;</Box>
+          <CodeIcon />
         </IconButton>
         {codeSelected && (
           <>
@@ -196,6 +202,13 @@ const Menu: React.FC = () => {
                 ))}
               </Select>
             </Box>
+            <IconButton color={codeLineNumbers ? 'secondary' : 'inherit'} onClick={() => {
+              const val = !codeLineNumbers;
+              setCodeLineNumbers(val);
+              updateSelectedCodeLineNumbers(val);
+            }} sx={{ mr: 1 }}>
+              <FormatListNumberedIcon />
+            </IconButton>
           </>
         )}
         {drawingMode && (

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,14 +7,13 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import BrushIcon from '@mui/icons-material/Brush';
-import CodeIcon from '@mui/icons-material/Code';
-
-const codeLanguages = ['typescript', 'javascript', 'python', 'css', 'html'];
+const codeLanguages = highlightLangs as readonly string[];
+const codeThemes = highlightThemes as readonly string[];
 
 const Menu: React.FC = () => {
   const app = useContext(AppContext);
@@ -26,6 +25,8 @@ const Menu: React.FC = () => {
   const codeSelected = app?.codeSelected ?? false;
   const codeLanguage = app?.codeLanguage ?? 'typescript';
   const setCodeLanguage = app?.setCodeLanguage ?? (() => {});
+  const codeTheme = app?.codeTheme ?? 'nord';
+  const setCodeTheme = app?.setCodeTheme ?? (() => {});
   const addBoard = app?.addBoard ?? (() => {});
   const drawingMode = app?.drawingMode ?? false;
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
@@ -45,6 +46,7 @@ const Menu: React.FC = () => {
       if (el && d3.select(el).classed('code-block')) {
         const data = d3.select(el).datum() as any;
         setCodeLanguage(data.lang ?? 'typescript');
+        setCodeTheme(data.theme ?? 'nord');
       }
     };
     window.addEventListener('stickyselectionchange', handler as EventListener);
@@ -136,24 +138,41 @@ const Menu: React.FC = () => {
           <BrushIcon />
         </IconButton>
         <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
-          <CodeIcon />
+          <Box component="span" sx={{ fontFamily: 'monospace', fontWeight: 'bold' }}>&lt;/&gt;</Box>
         </IconButton>
         {codeSelected && (
-          <Box id="code-lang-select" sx={{ mr: 2 }}>
-            <Select
-              size="small"
-              value={codeLanguage}
-              onChange={(e) => {
-                const val = e.target.value as string;
-                setCodeLanguage(val);
-                updateSelectedCodeLang(val);
-              }}
-            >
-              {codeLanguages.map((l) => (
-                <MenuItem key={l} value={l}>{l}</MenuItem>
-              ))}
-            </Select>
-          </Box>
+          <>
+            <Box id="code-lang-select" sx={{ mr: 2 }}>
+              <Select
+                size="small"
+                value={codeLanguage}
+                onChange={(e) => {
+                  const val = e.target.value as string;
+                  setCodeLanguage(val);
+                  updateSelectedCodeLang(val);
+                }}
+              >
+                {codeLanguages.map((l) => (
+                  <MenuItem key={l} value={l}>{l}</MenuItem>
+                ))}
+              </Select>
+            </Box>
+            <Box id="code-theme-select" sx={{ mr: 2 }}>
+              <Select
+                size="small"
+                value={codeTheme}
+                onChange={(e) => {
+                  const val = e.target.value as string;
+                  setCodeTheme(val);
+                  updateSelectedCodeTheme(val);
+                }}
+              >
+                {codeThemes.map((t) => (
+                  <MenuItem key={t} value={t}>{t}</MenuItem>
+                ))}
+              </Select>
+            </Box>
+          </>
         )}
         {drawingMode && (
           <Box id="brush-width-select" sx={{ mr: 2 }}>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,11 +7,13 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import BrushIcon from '@mui/icons-material/Brush';
+
+const codeLanguages = ['typescript', 'javascript', 'python', 'css', 'html'];
 
 const Menu: React.FC = () => {
   const app = useContext(AppContext);
@@ -20,6 +22,9 @@ const Menu: React.FC = () => {
   const stickyAlign = app?.stickyAlign ?? 'center';
   const setStickyAlign = app?.setStickyAlign ?? (() => {});
   const stickySelected = app?.stickySelected ?? false;
+  const codeSelected = app?.codeSelected ?? false;
+  const codeLanguage = app?.codeLanguage ?? 'typescript';
+  const setCodeLanguage = app?.setCodeLanguage ?? (() => {});
   const addBoard = app?.addBoard ?? (() => {});
   const drawingMode = app?.drawingMode ?? false;
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
@@ -35,6 +40,10 @@ const Menu: React.FC = () => {
         setFontSize(data.fontSize != null ? data.fontSize.toString() : 'auto');
       } else {
         setFontSize('auto');
+      }
+      if (el && d3.select(el).classed('code-block')) {
+        const data = d3.select(el).datum() as any;
+        setCodeLanguage(data.lang ?? 'typescript');
       }
     };
     window.addEventListener('stickyselectionchange', handler as EventListener);
@@ -125,6 +134,26 @@ const Menu: React.FC = () => {
         <IconButton color={drawingMode ? 'secondary' : 'inherit'} onClick={() => setDrawingMode(!drawingMode)} sx={{ mr: 1 }}>
           <BrushIcon />
         </IconButton>
+        <IconButton onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
+          <Typography fontSize="small">{'</>'}</Typography>
+        </IconButton>
+        {codeSelected && (
+          <Box id="code-lang-select" sx={{ mr: 2 }}>
+            <Select
+              size="small"
+              value={codeLanguage}
+              onChange={(e) => {
+                const val = e.target.value as string;
+                setCodeLanguage(val);
+                updateSelectedCodeLang(val);
+              }}
+            >
+              {codeLanguages.map((l) => (
+                <MenuItem key={l} value={l}>{l}</MenuItem>
+              ))}
+            </Select>
+          </Box>
+        )}
         {drawingMode && (
           <Box id="brush-width-select" sx={{ mr: 2 }}>
             <Select

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -135,7 +135,7 @@ const Menu: React.FC = () => {
         <IconButton color={drawingMode ? 'secondary' : 'inherit'} onClick={() => setDrawingMode(!drawingMode)} sx={{ mr: 1 }}>
           <BrushIcon />
         </IconButton>
-        <IconButton onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
+        <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
           <CodeIcon />
         </IconButton>
         {codeSelected && (

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -12,6 +12,7 @@ import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import BrushIcon from '@mui/icons-material/Brush';
+import CodeIcon from '@mui/icons-material/Code';
 
 const codeLanguages = ['typescript', 'javascript', 'python', 'css', 'html'];
 
@@ -135,7 +136,7 @@ const Menu: React.FC = () => {
           <BrushIcon />
         </IconButton>
         <IconButton onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
-          <Typography fontSize="small">{'</>'}</Typography>
+          <CodeIcon />
         </IconButton>
         {codeSelected && (
           <Box id="code-lang-select" sx={{ mr: 2 }}>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,7 +7,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, highlightLangs, highlightThemes } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
@@ -27,12 +27,15 @@ const Menu: React.FC = () => {
   const setCodeLanguage = app?.setCodeLanguage ?? (() => {});
   const codeTheme = app?.codeTheme ?? 'nord';
   const setCodeTheme = app?.setCodeTheme ?? (() => {});
+  const codeFontSize = app?.codeFontSize ?? 14;
+  const setCodeFontSize = app?.setCodeFontSize ?? (() => {});
   const addBoard = app?.addBoard ?? (() => {});
   const drawingMode = app?.drawingMode ?? false;
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
   const brushWidth = app?.brushWidth ?? 'auto';
   const setBrushWidth = app?.setBrushWidth ?? (() => {});
   const [fontSize, setFontSize] = React.useState<string>('auto');
+  const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
 
   React.useEffect(() => {
     const handler = (e: any) => {
@@ -43,10 +46,15 @@ const Menu: React.FC = () => {
       } else {
         setFontSize('auto');
       }
+      if (!el || !d3.select(el).classed('code-block')) {
+        setCodeSize(codeFontSize);
+      }
       if (el && d3.select(el).classed('code-block')) {
         const data = d3.select(el).datum() as any;
         setCodeLanguage(data.lang ?? 'typescript');
         setCodeTheme(data.theme ?? 'nord');
+        setCodeFontSize(data.fontSize ?? codeFontSize);
+        setCodeSize(data.fontSize ?? codeFontSize);
       }
     };
     window.addEventListener('stickyselectionchange', handler as EventListener);
@@ -169,6 +177,22 @@ const Menu: React.FC = () => {
               >
                 {codeThemes.map((t) => (
                   <MenuItem key={t} value={t}>{t}</MenuItem>
+                ))}
+              </Select>
+            </Box>
+            <Box id="code-font-select" sx={{ mr: 2 }}>
+              <Select
+                size="small"
+                value={codeSize}
+                onChange={(e) => {
+                  const val = parseInt(e.target.value as string);
+                  setCodeSize(val);
+                  setCodeFontSize(val);
+                  updateSelectedCodeFontSize(val);
+                }}
+              >
+                {Array.from({ length: 22 }, (_, i) => 6 + i * 2).map((s) => (
+                  <MenuItem key={s} value={s}>{`${s}px`}</MenuItem>
                 ))}
               </Select>
             </Box>

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -12,6 +12,10 @@ interface AppState {
   setStickyAlign: React.Dispatch<React.SetStateAction<'left' | 'center' | 'right'>>;
   stickySelected: boolean;
   setStickySelected: React.Dispatch<React.SetStateAction<boolean>>;
+  codeSelected: boolean;
+  setCodeSelected: React.Dispatch<React.SetStateAction<boolean>>;
+  codeLanguage: string;
+  setCodeLanguage: React.Dispatch<React.SetStateAction<string>>;
   boards: number[];
   addBoard: () => void;
   debug: boolean;
@@ -31,6 +35,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [stickyColor, setStickyColor] = useState<string>(noteColors[0]);
   const [stickyAlign, setStickyAlign] = useState<'left' | 'center' | 'right'>('center');
   const [stickySelected, setStickySelected] = useState<boolean>(false);
+  const [codeSelected, setCodeSelected] = useState<boolean>(false);
+  const [codeLanguage, setCodeLanguage] = useState<string>('typescript');
   const [boards, setBoards] = useState<number[]>([0]);
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
@@ -58,7 +64,28 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   }, [debug]);
 
   return (
-    <AppContext.Provider value={{ data, setData, stickyColor, setStickyColor, stickyAlign, setStickyAlign, stickySelected, setStickySelected, boards, addBoard, debug, setDebug, drawingMode, setDrawingMode, brushWidth, setBrushWidth }}>
+    <AppContext.Provider value={{
+      data,
+      setData,
+      stickyColor,
+      setStickyColor,
+      stickyAlign,
+      setStickyAlign,
+      stickySelected,
+      setStickySelected,
+      codeSelected,
+      setCodeSelected,
+      codeLanguage,
+      setCodeLanguage,
+      boards,
+      addBoard,
+      debug,
+      setDebug,
+      drawingMode,
+      setDrawingMode,
+      brushWidth,
+      setBrushWidth,
+    }}>
       {children}
     </AppContext.Provider>
   );

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -20,8 +20,6 @@ interface AppState {
   setCodeTheme: React.Dispatch<React.SetStateAction<string>>;
   codeFontSize: number;
   setCodeFontSize: React.Dispatch<React.SetStateAction<number>>;
-  codeLineNumbers: boolean;
-  setCodeLineNumbers: React.Dispatch<React.SetStateAction<boolean>>;
   boards: number[];
   addBoard: () => void;
   debug: boolean;
@@ -45,7 +43,6 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [codeLanguage, setCodeLanguage] = useState<string>('typescript');
   const [codeTheme, setCodeTheme] = useState<string>('github-dark');
   const [codeFontSize, setCodeFontSize] = useState<number>(14);
-  const [codeLineNumbers, setCodeLineNumbers] = useState<boolean>(false);
   const [boards, setBoards] = useState<number[]>([0]);
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
@@ -90,8 +87,6 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setCodeTheme,
       codeFontSize,
       setCodeFontSize,
-      codeLineNumbers,
-      setCodeLineNumbers,
       boards,
       addBoard,
       debug,

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -20,6 +20,8 @@ interface AppState {
   setCodeTheme: React.Dispatch<React.SetStateAction<string>>;
   codeFontSize: number;
   setCodeFontSize: React.Dispatch<React.SetStateAction<number>>;
+  codeLineNumbers: boolean;
+  setCodeLineNumbers: React.Dispatch<React.SetStateAction<boolean>>;
   boards: number[];
   addBoard: () => void;
   debug: boolean;
@@ -41,8 +43,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [stickySelected, setStickySelected] = useState<boolean>(false);
   const [codeSelected, setCodeSelected] = useState<boolean>(false);
   const [codeLanguage, setCodeLanguage] = useState<string>('typescript');
-  const [codeTheme, setCodeTheme] = useState<string>('nord');
+  const [codeTheme, setCodeTheme] = useState<string>('github-dark');
   const [codeFontSize, setCodeFontSize] = useState<number>(14);
+  const [codeLineNumbers, setCodeLineNumbers] = useState<boolean>(false);
   const [boards, setBoards] = useState<number[]>([0]);
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
@@ -87,6 +90,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setCodeTheme,
       codeFontSize,
       setCodeFontSize,
+      codeLineNumbers,
+      setCodeLineNumbers,
       boards,
       addBoard,
       debug,

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -16,6 +16,8 @@ interface AppState {
   setCodeSelected: React.Dispatch<React.SetStateAction<boolean>>;
   codeLanguage: string;
   setCodeLanguage: React.Dispatch<React.SetStateAction<string>>;
+  codeTheme: string;
+  setCodeTheme: React.Dispatch<React.SetStateAction<string>>;
   boards: number[];
   addBoard: () => void;
   debug: boolean;
@@ -37,6 +39,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [stickySelected, setStickySelected] = useState<boolean>(false);
   const [codeSelected, setCodeSelected] = useState<boolean>(false);
   const [codeLanguage, setCodeLanguage] = useState<string>('typescript');
+  const [codeTheme, setCodeTheme] = useState<string>('nord');
   const [boards, setBoards] = useState<number[]>([0]);
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
@@ -77,6 +80,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setCodeSelected,
       codeLanguage,
       setCodeLanguage,
+      codeTheme,
+      setCodeTheme,
       boards,
       addBoard,
       debug,

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -18,6 +18,8 @@ interface AppState {
   setCodeLanguage: React.Dispatch<React.SetStateAction<string>>;
   codeTheme: string;
   setCodeTheme: React.Dispatch<React.SetStateAction<string>>;
+  codeFontSize: number;
+  setCodeFontSize: React.Dispatch<React.SetStateAction<number>>;
   boards: number[];
   addBoard: () => void;
   debug: boolean;
@@ -40,6 +42,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [codeSelected, setCodeSelected] = useState<boolean>(false);
   const [codeLanguage, setCodeLanguage] = useState<string>('typescript');
   const [codeTheme, setCodeTheme] = useState<string>('nord');
+  const [codeFontSize, setCodeFontSize] = useState<number>(14);
   const [boards, setBoards] = useState<number[]>([0]);
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
@@ -82,6 +85,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setCodeLanguage,
       codeTheme,
       setCodeTheme,
+      codeFontSize,
+      setCodeFontSize,
       boards,
       addBoard,
       debug,

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -387,7 +387,8 @@ const GuitarBoard: React.FC = () => {
       .attr('y', 0)
       .attr('width', codeWidth)
       .attr('height', codeHeight)
-      .attr('fill', '#f5f5f5');
+      .attr('stroke', '#333')
+      .attr('stroke-width', 1);
 
     const fo = group.append('foreignObject')
       .attr('x', 0)

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -407,7 +407,8 @@ const GuitarBoard: React.FC = () => {
         .attr('contentEditable', 'true')
         .classed('edit-mode', true)
         .on('mousedown.edit', (event: MouseEvent) => event.stopPropagation())
-        .on('keydown.edit', (event: KeyboardEvent) => event.stopPropagation());
+        .on('keydown.edit', (event: KeyboardEvent) => event.stopPropagation())
+        .on('keyup.edit', (event: KeyboardEvent) => event.stopPropagation());
       setTimeout(() => { (pre.node() as HTMLElement)?.focus(); }, 0);
     });
 
@@ -418,7 +419,8 @@ const GuitarBoard: React.FC = () => {
         .attr('contentEditable', 'false')
         .classed('edit-mode', false)
         .on('mousedown.edit', null)
-        .on('keydown.edit', null);
+        .on('keydown.edit', null)
+        .on('keyup.edit', null);
       highlightCode(data.code, data.lang).then(res => {
         pre.style('background-color', res.background).html(res.html);
       });
@@ -671,8 +673,12 @@ const GuitarBoard: React.FC = () => {
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       const active = document.activeElement as HTMLElement | null;
-      if (active && active.classList.contains('sticky-text') && active.getAttribute('contentEditable') === 'true') {
-        return; // let the browser handle paste inside editable sticky
+      if (
+        active &&
+        active.getAttribute('contentEditable') === 'true' &&
+        (active.classList.contains('sticky-text') || active.classList.contains('edit-mode'))
+      ) {
+        return; // allow paste in editable fields
       }
       const text = event.clipboardData?.getData('text/plain');
       if (text) {
@@ -728,7 +734,11 @@ const GuitarBoard: React.FC = () => {
   useEffect(() => {
     const handleCopy = (e: ClipboardEvent) => {
       const active = document.activeElement as HTMLElement | null;
-      if (active && active.classList.contains('sticky-text') && active.getAttribute('contentEditable') === 'true') {
+      if (
+        active &&
+        active.getAttribute('contentEditable') === 'true' &&
+        (active.classList.contains('sticky-text') || active.classList.contains('edit-mode'))
+      ) {
         return;
       }
       const info = getSelectedElementData();

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -46,7 +46,7 @@ interface PastedVideoDatum { id: string; type: 'video'; url: string; videoId: st
 
 interface StickyNoteDatum { id: string; type: 'sticky'; text: string; align: 'left' | 'center' | 'right' }
 
-interface CodeBlockDatum { id: string; type: 'code'; code: string; lang: string; theme: string; fontSize: number; lineNumbers: boolean }
+interface CodeBlockDatum { id: string; type: 'code'; code: string; lang: string; theme: string; fontSize: number }
 
 const stickyWidth = 225;
 const stickyHeight = 150;
@@ -75,7 +75,6 @@ const GuitarBoard: React.FC = () => {
   const codeLanguage = app?.codeLanguage ?? 'typescript';
   const codeTheme = app?.codeTheme ?? 'github-dark';
   const codeFontSize = app?.codeFontSize ?? 14;
-  const codeLineNumbers = app?.codeLineNumbers ?? false;
   const drawingMode = app?.drawingMode ?? false;
   const brushWidth = app?.brushWidth ?? 'auto';
   const svgRef = useRef<SVGSVGElement | null>(null);
@@ -378,7 +377,6 @@ const GuitarBoard: React.FC = () => {
         lang,
         theme,
         fontSize: size,
-        lineNumbers: codeLineNumbers,
         width: codeWidth,
         height: codeHeight,
         transform: { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 },
@@ -405,7 +403,7 @@ const GuitarBoard: React.FC = () => {
       .style('font-family', 'monospace')
       .style('font-size', `${size}px`);
 
-    highlightCode(code, lang, theme, codeLineNumbers).then(res => {
+    highlightCode(code, lang, theme).then(res => {
       pre.style('background-color', res.background)
         .style('font-size', `${size}px`)
         .html(res.html);
@@ -417,7 +415,13 @@ const GuitarBoard: React.FC = () => {
         .classed('edit-mode', true)
         .style('color', theme === 'github-dark' ? '#fff' : '#000')
         .on('mousedown.edit', (event: MouseEvent) => event.stopPropagation())
-        .on('keydown.edit', (event: KeyboardEvent) => event.stopPropagation())
+        .on('keydown.edit', (event: KeyboardEvent) => {
+          if (event.ctrlKey && event.key === 'Enter') {
+            (pre.node() as HTMLElement).blur();
+            event.preventDefault();
+          }
+          event.stopPropagation();
+        })
         .on('keyup.edit', (event: KeyboardEvent) => event.stopPropagation());
       setTimeout(() => { (pre.node() as HTMLElement)?.focus(); }, 0);
     });
@@ -431,12 +435,13 @@ const GuitarBoard: React.FC = () => {
         .on('mousedown.edit', null)
         .on('keydown.edit', null)
         .on('keyup.edit', null);
-      highlightCode(data.code, data.lang, data.theme, data.lineNumbers).then(res => {
+      highlightCode(data.code, data.lang, data.theme).then(res => {
         pre.style('background-color', res.background)
           .style('font-size', `${data.fontSize}px`)
           .html(res.html);
       });
       pre.style('color', null);
+      window.getSelection()?.removeAllRanges();
     });
 
     applyTransform(group, { translateX: pos.x, translateY: pos.y, scaleX: 1, scaleY: 1, rotate: 0 });
@@ -485,11 +490,9 @@ const GuitarBoard: React.FC = () => {
       applyTransform(g, { ...info.data.transform, translateX: pos.x, translateY: pos.y });
     } else if (info.type === 'code') {
       const g = addCodeBlock(info.data.code, info.data.lang, info.data.theme, pos, info.data.fontSize);
-      const d = g.datum() as any;
-      d.lineNumbers = info.data.lineNumbers;
       const pre = g.select<HTMLPreElement>('foreignObject > pre').node();
       if (pre) {
-        highlightCode(info.data.code, info.data.lang, info.data.theme, info.data.lineNumbers).then(res => {
+        highlightCode(info.data.code, info.data.lang, info.data.theme).then(res => {
           pre.innerHTML = res.html;
           pre.style.backgroundColor = res.background;
           pre.style.fontSize = `${info.data.fontSize}px`;
@@ -637,11 +640,21 @@ const GuitarBoard: React.FC = () => {
   }, [addCodeBlock, codeLanguage, codeTheme, codeFontSize]);
 
   useEffect(() => {
+    const handler = () => addSticky('', cursorRef.current);
+    window.addEventListener('createsticky', handler as EventListener);
+    return () => window.removeEventListener('createsticky', handler as EventListener);
+  }, [addSticky]);
+
+  useEffect(() => {
     const handle = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.getAttribute('contenteditable') === 'true')) return;
       if (e.key === 'c' && !e.ctrlKey && !croppableSelected) {
         window.dispatchEvent(new Event('createcodeblock'));
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      } else if (e.key === 'n' && !e.ctrlKey) {
+        window.dispatchEvent(new Event('createsticky'));
         e.preventDefault();
         e.stopImmediatePropagation();
       }

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -398,15 +398,16 @@ const GuitarBoard: React.FC = () => {
       .style('overflow', 'auto')
       .style('font-family', 'monospace');
 
-    highlightCode(code, lang).then(html => {
-      pre.html(html);
+    highlightCode(code, lang).then(res => {
+      pre.style('background-color', res.background).html(res.html);
     });
 
     group.on('dblclick', () => {
       pre
         .attr('contentEditable', 'true')
         .classed('edit-mode', true)
-        .on('mousedown.edit', (event: MouseEvent) => event.stopPropagation());
+        .on('mousedown.edit', (event: MouseEvent) => event.stopPropagation())
+        .on('keydown.edit', (event: KeyboardEvent) => event.stopPropagation());
       setTimeout(() => { (pre.node() as HTMLElement)?.focus(); }, 0);
     });
 
@@ -416,9 +417,10 @@ const GuitarBoard: React.FC = () => {
       pre
         .attr('contentEditable', 'false')
         .classed('edit-mode', false)
-        .on('mousedown.edit', null);
-      highlightCode(data.code, data.lang).then(html => {
-        pre.html(html);
+        .on('mousedown.edit', null)
+        .on('keydown.edit', null);
+      highlightCode(data.code, data.lang).then(res => {
+        pre.style('background-color', res.background).html(res.html);
       });
     });
 

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -1,6 +1,7 @@
 import * as d3 from 'd3';
 import { BaseType, Selection } from 'd3';
-import { getHighlighter, type Highlighter } from 'shiki';
+import { getHighlighter, type Highlighter, setWasm } from 'shiki';
+import onigWasm from 'shiki/onig.wasm?url';
 
 let zoomTransform: d3.ZoomTransform = d3.zoomIdentity;
 let svgRoot: SVGSVGElement | null = null;
@@ -194,6 +195,7 @@ export interface HighlightResult { html: string; background: string }
 export async function highlightCode(code: string, lang: string): Promise<HighlightResult> {
     try {
         if (!highlighterPromise) {
+            setWasm(onigWasm);
             highlighterPromise = getHighlighter({ theme: 'github-dark' });
         }
         const highlighter = await highlighterPromise;

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -386,6 +386,7 @@ export async function updateSelectedCodeLang(lang: string) {
             const { html, background } = await highlightCode(data.code, lang, data.theme ?? 'nord');
             pre.innerHTML = html;
             pre.style.backgroundColor = background;
+            pre.style.fontSize = `${data.fontSize ?? 14}px`;
         }
     }
 }
@@ -399,7 +400,17 @@ export async function updateSelectedCodeTheme(theme: string) {
             const { html, background } = await highlightCode(data.code, data.lang, theme);
             pre.innerHTML = html;
             pre.style.backgroundColor = background;
+            pre.style.fontSize = `${data.fontSize ?? 14}px`;
         }
+    }
+}
+
+export function updateSelectedCodeFontSize(size: number) {
+    if (selectedElement && selectedElement.classed('code-block')) {
+        const data = selectedElement.datum() as any;
+        data.fontSize = size;
+        selectedElement.select<HTMLPreElement>('foreignObject > pre')
+            .style('font-size', `${size}px`);
     }
 }
 
@@ -509,7 +520,7 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                     newScaleY = ratio;
                 }
 
-                if (element.classed('sticky-note')) {
+                if (element.classed('sticky-note') || element.classed('code-block')) {
                     const stickyData = element.datum() as any;
                     const width = data.origWidth * newScaleX;
                     const height = data.origHeight * newScaleY;
@@ -554,7 +565,7 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                 }
             })
             .on('end', function () {
-                if (element.classed('sticky-note') && typeof options.onResizeEnd === 'function') {
+                if ((element.classed('sticky-note') || element.classed('code-block')) && typeof options.onResizeEnd === 'function') {
                     options.onResizeEnd(element);
                 }
                 updateDebugCross(element);


### PR DESCRIPTION
## Summary
- add code block tool with syntax highlighting via Shiki
- support language choice from the menu
- allow inserting code blocks with `c` key when no image is selected
- document new shortcut

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68599b630a5c832ea7c4480ef0089b37