### PR TITLE
Implement basic line drawing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://sergej-popov.github.io/tremolo/
 - Select a pasted object and press **Delete** to remove it.
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
-- Draw straight lines and connect them to other elements.
+- Draw straight lines. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ https://sergej-popov.github.io/tremolo/
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Draw lines with straight, arched or cornered style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
+- Change a line's colour from the sticky note palette and choose connection style: circle, arrow, filled triangle or none.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://sergej-popov.github.io/tremolo/
 - Select a pasted object and press **Delete** to remove it.
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
-- Draw lines with straight or arched style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
+- Draw lines with straight, arched or cornered style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://sergej-popov.github.io/tremolo/
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Draw lines with straight, arched or cornered style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
-- Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none.
+- Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none. Lines default to black while sticky notes keep their original colour.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://sergej-popov.github.io/tremolo/
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Draw lines with straight, arched or cornered style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
-- Change a line's colour from the sticky note palette and choose connection style: circle, arrow, filled triangle or none.
+- Change a line's colour from the sticky note palette and set the start and end connection style independently: circle, arrow, filled triangle or none.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ https://sergej-popov.github.io/tremolo/
 - Select a pasted object and press **Delete** to remove it.
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
+- Draw straight lines and connect them to other elements.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.
@@ -41,6 +42,7 @@ https://sergej-popov.github.io/tremolo/
 - **b** – toggle the brush drawing mode.
 - **n** – insert a sticky note.
 - **c** – insert a code block.
+- **l** – insert a line.
 
 ### Images
 - **c** – crop selected image (or double-click an image to toggle cropping).
@@ -48,11 +50,10 @@ https://sergej-popov.github.io/tremolo/
 ## TODO general
 
 1. [Large] Provide undo and redo support for board changes.
-2. Connectiing lines
-3. Add a dark and light theme toggle for the fretboard interface.
-4. Draw style themes
-5. Tool pannel
-6. Contextual menu panel
+2. Add a dark and light theme toggle for the fretboard interface.
+3. Draw style themes
+4. Tool pannel
+5. Contextual menu panel
 
 ## TODO collaboration
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://sergej-popov.github.io/tremolo/
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
 - Draw lines with straight, arched or cornered style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
-- Change a line's colour from the sticky note palette and set the start and end connection style independently: circle, arrow, filled triangle or none.
+- Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://sergej-popov.github.io/tremolo/
 - Select a pasted object and press **Delete** to remove it.
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
-- Draw straight lines. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
+- Draw lines with straight or arched style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ https://sergej-popov.github.io/tremolo/
 - Select a pasted object and press **Delete** to remove it.
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
-- Draw lines with straight, arched or cornered style. Endpoints snap to subtle connectors at each element's side and stay attached when those elements move.
-- Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none. Lines default to black while sticky notes keep their original colour.
+- Draw lines with straight, arched or cornered style. New lines start arched with triangle connectors and snap to subtle connectors at each element's side, remaining attached when those elements move.
+- Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none. Lines default to black.
 - Quickly add predefined chords or scales or display all notes.
 - Choose sticky note colour from the palette in the header when a sticky note is selected.
 - Change sticky note text alignment using the header buttons when a note is selected.

--- a/src/App.css
+++ b/src/App.css
@@ -139,7 +139,8 @@
 
 .line-handle {
     cursor: crosshair;
-    fill: black;
+    fill: transparent;
+    stroke: none;
 }
 #root, html, body {
     height: 100%;

--- a/src/App.css
+++ b/src/App.css
@@ -131,6 +131,16 @@
     pointer-events: none;
     opacity: 1;
 }
+
+.connect-handle {
+    cursor: crosshair;
+    fill: #7fbbf7;
+}
+
+.line-handle {
+    cursor: crosshair;
+    fill: black;
+}
 #root, html, body {
     height: 100%;
     margin: 0;

--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -24,6 +24,7 @@ const shortcuts: ShortcutSection[] = [
       { key: 'b', action: 'Toggle brush drawing mode' },
       { key: 'n', action: 'Insert sticky note' },
       { key: 'c', action: 'Insert code block' },
+      { key: 'l', action: 'Insert line' },
     ],
   },
   {

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,7 +7,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, highlightLangs, highlightThemes } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
@@ -39,6 +39,8 @@ const Menu: React.FC = () => {
   const setBrushWidth = app?.setBrushWidth ?? (() => {});
   const [fontSize, setFontSize] = React.useState<string>('auto');
   const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
+  const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc'>('direct');
+  const [lineSelected, setLineSelected] = React.useState(false);
 
   React.useEffect(() => {
     const handler = (e: any) => {
@@ -62,6 +64,21 @@ const Menu: React.FC = () => {
     };
     window.addEventListener('stickyselectionchange', handler as EventListener);
     return () => window.removeEventListener('stickyselectionchange', handler as EventListener);
+  }, []);
+
+  React.useEffect(() => {
+    const handler = (e: any) => {
+      const el: HTMLElement | null = e.detail;
+      if (el && d3.select(el).classed('line-element')) {
+        const data = d3.select(el).datum() as any;
+        setLineSelected(true);
+        setLineStyle(data.style ?? 'direct');
+      } else {
+        setLineSelected(false);
+      }
+    };
+    window.addEventListener('lineselectionchange', handler as EventListener);
+    return () => window.removeEventListener('lineselectionchange', handler as EventListener);
   }, []);
 
   return (
@@ -157,6 +174,22 @@ const Menu: React.FC = () => {
         <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createcodeblock'))} sx={{ mr: 1 }}>
           <CodeIcon />
         </IconButton>
+        {lineSelected && (
+          <Box id="line-style-select" sx={{ mr: 2 }}>
+            <Select
+              size="small"
+              value={lineStyle}
+              onChange={(e) => {
+                const val = e.target.value as 'direct' | 'arc';
+                setLineStyle(val);
+                updateSelectedLineStyle(val);
+              }}
+            >
+              <MenuItem value="direct">Direct</MenuItem>
+              <MenuItem value="arc">Arc</MenuItem>
+            </Select>
+          </Box>
+        )}
         {codeSelected && (
           <>
             <Box id="code-lang-select" sx={{ mr: 2 }}>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -40,6 +40,8 @@ const Menu: React.FC = () => {
   const [fontSize, setFontSize] = React.useState<string>('auto');
   const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
   const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc' | 'corner'>('direct');
+  const [lineColor, setLineColor] = React.useState<string>(noteColors[0]);
+  const [lineConn, setLineConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
   const [lineSelected, setLineSelected] = React.useState(false);
 
   React.useEffect(() => {
@@ -73,6 +75,8 @@ const Menu: React.FC = () => {
         const data = d3.select(el).datum() as any;
         setLineSelected(true);
         setLineStyle(data.style ?? 'direct');
+        setLineColor(data.color ?? noteColors[0]);
+        setLineConn(data.conn ?? 'circle');
       } else {
         setLineSelected(false);
       }
@@ -175,21 +179,56 @@ const Menu: React.FC = () => {
           <CodeIcon />
         </IconButton>
         {lineSelected && (
-          <Box id="line-style-select" sx={{ mr: 2 }}>
-            <Select
-              size="small"
-              value={lineStyle}
-              onChange={(e) => {
-                const val = e.target.value as 'direct' | 'arc' | 'corner';
-                setLineStyle(val);
-                updateSelectedLineStyle(val);
-              }}
-            >
-              <MenuItem value="direct">Direct</MenuItem>
-              <MenuItem value="arc">Arc</MenuItem>
-              <MenuItem value="corner">Corner</MenuItem>
-            </Select>
-          </Box>
+          <>
+            <Box id="line-color-select" sx={{ mr: 2 }}>
+              <Select
+                size="small"
+                value={lineColor}
+                onChange={(e) => {
+                  const c = e.target.value as string;
+                  setLineColor(c);
+                  updateSelectedLineColor(c);
+                }}
+              >
+                {noteColors.map((c) => (
+                  <MenuItem value={c} key={c}>
+                    <Box sx={{ width: 20, height: 20, backgroundColor: c }} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </Box>
+            <Box id="line-conn-select" sx={{ mr: 2 }}>
+              <Select
+                size="small"
+                value={lineConn}
+                onChange={(e) => {
+                  const s = e.target.value as 'circle' | 'arrow' | 'triangle' | 'none';
+                  setLineConn(s);
+                  updateSelectedConnectionStyle(s);
+                }}
+              >
+                <MenuItem value="circle">Circle</MenuItem>
+                <MenuItem value="arrow">Arrow</MenuItem>
+                <MenuItem value="triangle">Triangle</MenuItem>
+                <MenuItem value="none">None</MenuItem>
+              </Select>
+            </Box>
+            <Box id="line-style-select" sx={{ mr: 2 }}>
+              <Select
+                size="small"
+                value={lineStyle}
+                onChange={(e) => {
+                  const val = e.target.value as 'direct' | 'arc' | 'corner';
+                  setLineStyle(val);
+                  updateSelectedLineStyle(val);
+                }}
+              >
+                <MenuItem value="direct">Direct</MenuItem>
+                <MenuItem value="arc">Arc</MenuItem>
+                <MenuItem value="corner">Corner</MenuItem>
+              </Select>
+            </Box>
+          </>
         )}
         {codeSelected && (
           <>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -14,6 +14,7 @@ import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import BrushIcon from '@mui/icons-material/Brush';
 import CodeIcon from '@mui/icons-material/Code';
 import StickyNote2Icon from '@mui/icons-material/StickyNote2';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
 const codeLanguages = highlightLangs as readonly string[];
 const codeThemes = highlightThemes as readonly string[];
 
@@ -146,6 +147,9 @@ const Menu: React.FC = () => {
         )}
         <IconButton color={drawingMode ? 'secondary' : 'inherit'} onClick={() => setDrawingMode(!drawingMode)} sx={{ mr: 1 }}>
           <BrushIcon />
+        </IconButton>
+        <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createline'))} sx={{ mr: 1 }}>
+          <ShowChartIcon />
         </IconButton>
         <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createsticky'))} sx={{ mr: 1 }}>
           <StickyNote2Icon />

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,7 +7,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
 import { noteColors } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, highlightLangs, highlightThemes } from './d3-ext';
+import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
@@ -41,7 +41,8 @@ const Menu: React.FC = () => {
   const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
   const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc' | 'corner'>('direct');
   const [lineColor, setLineColor] = React.useState<string>(noteColors[0]);
-  const [lineConn, setLineConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
+  const [lineStartConn, setLineStartConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
+  const [lineEndConn, setLineEndConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
   const [lineSelected, setLineSelected] = React.useState(false);
 
   React.useEffect(() => {
@@ -76,7 +77,8 @@ const Menu: React.FC = () => {
         setLineSelected(true);
         setLineStyle(data.style ?? 'direct');
         setLineColor(data.color ?? noteColors[0]);
-        setLineConn(data.conn ?? 'circle');
+        setLineStartConn(data.startStyle ?? 'circle');
+        setLineEndConn(data.endStyle ?? 'circle');
       } else {
         setLineSelected(false);
       }
@@ -197,20 +199,36 @@ const Menu: React.FC = () => {
                 ))}
               </Select>
             </Box>
-            <Box id="line-conn-select" sx={{ mr: 2 }}>
+            <Box id="line-start-select" sx={{ mr: 2 }}>
               <Select
                 size="small"
-                value={lineConn}
+                value={lineStartConn}
                 onChange={(e) => {
                   const s = e.target.value as 'circle' | 'arrow' | 'triangle' | 'none';
-                  setLineConn(s);
-                  updateSelectedConnectionStyle(s);
+                  setLineStartConn(s);
+                  updateSelectedStartConnectionStyle(s);
                 }}
               >
-                <MenuItem value="circle">Circle</MenuItem>
-                <MenuItem value="arrow">Arrow</MenuItem>
-                <MenuItem value="triangle">Triangle</MenuItem>
-                <MenuItem value="none">None</MenuItem>
+                <MenuItem value="circle">Start Circle</MenuItem>
+                <MenuItem value="arrow">Start Arrow</MenuItem>
+                <MenuItem value="triangle">Start Triangle</MenuItem>
+                <MenuItem value="none">Start None</MenuItem>
+              </Select>
+            </Box>
+            <Box id="line-end-select" sx={{ mr: 2 }}>
+              <Select
+                size="small"
+                value={lineEndConn}
+                onChange={(e) => {
+                  const s = e.target.value as 'circle' | 'arrow' | 'triangle' | 'none';
+                  setLineEndConn(s);
+                  updateSelectedEndConnectionStyle(s);
+                }}
+              >
+                <MenuItem value="circle">End Circle</MenuItem>
+                <MenuItem value="arrow">End Arrow</MenuItem>
+                <MenuItem value="triangle">End Triangle</MenuItem>
+                <MenuItem value="none">End None</MenuItem>
               </Select>
             </Box>
             <Box id="line-style-select" sx={{ mr: 2 }}>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -6,7 +6,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import { AppContext } from './Store';
-import { noteColors } from './theme';
+import { noteColors, defaultLineColor } from './theme';
 import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
@@ -40,7 +40,7 @@ const Menu: React.FC = () => {
   const [fontSize, setFontSize] = React.useState<string>('auto');
   const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
   const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc' | 'corner'>('direct');
-  const [lineColor, setLineColor] = React.useState<string>(noteColors[0]);
+  const [lineColor, setLineColor] = React.useState<string>(defaultLineColor);
   const [lineStartConn, setLineStartConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
   const [lineEndConn, setLineEndConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
   const [lineSelected, setLineSelected] = React.useState(false);
@@ -76,7 +76,7 @@ const Menu: React.FC = () => {
         const data = d3.select(el).datum() as any;
         setLineSelected(true);
         setLineStyle(data.style ?? 'direct');
-        setLineColor(data.color ?? noteColors[0]);
+        setLineColor(data.color ?? defaultLineColor);
         setLineStartConn(data.startStyle ?? 'circle');
         setLineEndConn(data.endStyle ?? 'circle');
       } else {

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -39,10 +39,10 @@ const Menu: React.FC = () => {
   const setBrushWidth = app?.setBrushWidth ?? (() => {});
   const [fontSize, setFontSize] = React.useState<string>('auto');
   const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
-  const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc' | 'corner'>('direct');
+  const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc' | 'corner'>('arc');
   const [lineColor, setLineColor] = React.useState<string>(defaultLineColor);
-  const [lineStartConn, setLineStartConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
-  const [lineEndConn, setLineEndConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('circle');
+  const [lineStartConn, setLineStartConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('triangle');
+  const [lineEndConn, setLineEndConn] = React.useState<'circle' | 'arrow' | 'triangle' | 'none'>('triangle');
   const [lineSelected, setLineSelected] = React.useState(false);
 
   React.useEffect(() => {
@@ -75,10 +75,10 @@ const Menu: React.FC = () => {
       if (el && d3.select(el).classed('line-element')) {
         const data = d3.select(el).datum() as any;
         setLineSelected(true);
-        setLineStyle(data.style ?? 'direct');
+        setLineStyle(data.style ?? 'arc');
         setLineColor(data.color ?? defaultLineColor);
-        setLineStartConn(data.startStyle ?? 'circle');
-        setLineEndConn(data.endStyle ?? 'circle');
+        setLineStartConn(data.startStyle ?? 'triangle');
+        setLineEndConn(data.endStyle ?? 'triangle');
       } else {
         setLineSelected(false);
       }

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -39,7 +39,7 @@ const Menu: React.FC = () => {
   const setBrushWidth = app?.setBrushWidth ?? (() => {});
   const [fontSize, setFontSize] = React.useState<string>('auto');
   const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
-  const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc'>('direct');
+  const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc' | 'corner'>('direct');
   const [lineSelected, setLineSelected] = React.useState(false);
 
   React.useEffect(() => {
@@ -180,13 +180,14 @@ const Menu: React.FC = () => {
               size="small"
               value={lineStyle}
               onChange={(e) => {
-                const val = e.target.value as 'direct' | 'arc';
+                const val = e.target.value as 'direct' | 'arc' | 'corner';
                 setLineStyle(val);
                 updateSelectedLineStyle(val);
               }}
             >
               <MenuItem value="direct">Direct</MenuItem>
               <MenuItem value="arc">Arc</MenuItem>
+              <MenuItem value="corner">Corner</MenuItem>
             </Select>
           </Box>
         )}

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useContext, useCallback } from 'react';
 import * as d3 from 'd3';
-import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedConnectionStyle, applyLineAppearance } from '../d3-ext';
+import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, applyLineAppearance } from '../d3-ext';
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';
@@ -493,7 +493,7 @@ const GuitarBoard: React.FC = () => {
     const layer = svg.select<SVGGElement>('.lines');
     const group = layer.append('g')
       .attr('class', 'line-element')
-      .datum<{ id: string; type: 'line'; x1: number; y1: number; x2: number; y2: number; style: 'direct' | 'arc' | 'corner'; color: string; conn: 'circle' | 'arrow' | 'triangle' | 'none'; startConn?: ConnectionInfo; endConn?: ConnectionInfo }>({
+      .datum<{ id: string; type: 'line'; x1: number; y1: number; x2: number; y2: number; style: 'direct' | 'arc' | 'corner'; color: string; startStyle: 'circle' | 'arrow' | 'triangle' | 'none'; endStyle: 'circle' | 'arrow' | 'triangle' | 'none'; startConn?: ConnectionInfo; endConn?: ConnectionInfo }>({
         id: generateId(),
         type: 'line',
         x1: start.x,
@@ -502,7 +502,8 @@ const GuitarBoard: React.FC = () => {
         y2: end ? end.y : start.y,
         style: 'direct',
         color: noteColors[0],
-        conn: 'circle',
+        startStyle: 'circle',
+        endStyle: 'circle',
         startConn,
         endConn,
       });
@@ -567,7 +568,8 @@ const GuitarBoard: React.FC = () => {
     group.call(makeResizable);
     group.dispatch('click');
     updateSelectedLineColor(noteColors[0]);
-    updateSelectedConnectionStyle('circle');
+    updateSelectedStartConnectionStyle('circle');
+    updateSelectedEndConnectionStyle('circle');
     return group;
   }, []);
 

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -492,7 +492,7 @@ const GuitarBoard: React.FC = () => {
     const layer = svg.select<SVGGElement>('.lines');
     const group = layer.append('g')
       .attr('class', 'line-element')
-      .datum<{ id: string; type: 'line'; x1: number; y1: number; x2: number; y2: number; style: 'direct' | 'arc'; startConn?: ConnectionInfo; endConn?: ConnectionInfo }>({
+      .datum<{ id: string; type: 'line'; x1: number; y1: number; x2: number; y2: number; style: 'direct' | 'arc' | 'corner'; startConn?: ConnectionInfo; endConn?: ConnectionInfo }>({
         id: generateId(),
         type: 'line',
         x1: start.x,

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState, useContext, useCallback } from 'react';
 import * as d3 from 'd3';
-import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle } from '../d3-ext';
+import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedConnectionStyle } from '../d3-ext';
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';
+import { noteColors } from '../theme';
 import { Button, Slider, Drawer, Box, Typography, IconButton } from '@mui/material';
 import { AppContext } from '../Store';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
@@ -492,7 +493,7 @@ const GuitarBoard: React.FC = () => {
     const layer = svg.select<SVGGElement>('.lines');
     const group = layer.append('g')
       .attr('class', 'line-element')
-      .datum<{ id: string; type: 'line'; x1: number; y1: number; x2: number; y2: number; style: 'direct' | 'arc' | 'corner'; startConn?: ConnectionInfo; endConn?: ConnectionInfo }>({
+      .datum<{ id: string; type: 'line'; x1: number; y1: number; x2: number; y2: number; style: 'direct' | 'arc' | 'corner'; color: string; conn: 'circle' | 'arrow' | 'triangle' | 'none'; startConn?: ConnectionInfo; endConn?: ConnectionInfo }>({
         id: generateId(),
         type: 'line',
         x1: start.x,
@@ -500,14 +501,17 @@ const GuitarBoard: React.FC = () => {
         x2: end ? end.x : start.x + 100,
         y2: end ? end.y : start.y,
         style: 'direct',
+        color: noteColors[0],
+        conn: 'circle',
         startConn,
         endConn,
       });
     const path = group.append('path')
       .attr('d', linePath(group.datum()))
-      .attr('stroke', 'black')
+      .attr('stroke', noteColors[0])
       .attr('fill', 'none')
       .attr('stroke-width', 2);
+    applyLineAppearance(group as any);
     group.append('circle')
       .attr('class', 'line-handle start')
       .attr('r', 4)
@@ -562,6 +566,8 @@ const GuitarBoard: React.FC = () => {
         }));
     group.call(makeResizable);
     group.dispatch('click');
+    updateSelectedLineColor(noteColors[0]);
+    updateSelectedConnectionStyle('circle');
     return group;
   }, []);
 

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useContext, useCallback } from 'react';
 import * as d3 from 'd3';
-import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedConnectionStyle } from '../d3-ext';
+import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedConnectionStyle, applyLineAppearance } from '../d3-ext';
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -4,7 +4,7 @@ import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransfo
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';
-import { noteColors } from '../theme';
+import { noteColors, defaultLineColor } from '../theme';
 import { Button, Slider, Drawer, Box, Typography, IconButton } from '@mui/material';
 import { AppContext } from '../Store';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
@@ -501,7 +501,7 @@ const GuitarBoard: React.FC = () => {
         x2: end ? end.x : start.x + 100,
         y2: end ? end.y : start.y,
         style: 'direct',
-        color: noteColors[0],
+        color: defaultLineColor,
         startStyle: 'circle',
         endStyle: 'circle',
         startConn,
@@ -509,7 +509,7 @@ const GuitarBoard: React.FC = () => {
       });
     const path = group.append('path')
       .attr('d', linePath(group.datum()))
-      .attr('stroke', noteColors[0])
+      .attr('stroke', defaultLineColor)
       .attr('fill', 'none')
       .attr('stroke-width', 2);
     applyLineAppearance(group as any);
@@ -567,7 +567,7 @@ const GuitarBoard: React.FC = () => {
         }));
     group.call(makeResizable);
     group.dispatch('click');
-    updateSelectedLineColor(noteColors[0]);
+    updateSelectedLineColor(defaultLineColor);
     updateSelectedStartConnectionStyle('circle');
     updateSelectedEndConnectionStyle('circle');
     return group;

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -500,10 +500,10 @@ const GuitarBoard: React.FC = () => {
         y1: start.y,
         x2: end ? end.x : start.x + 100,
         y2: end ? end.y : start.y,
-        style: 'direct',
+        style: 'arc',
         color: defaultLineColor,
-        startStyle: 'circle',
-        endStyle: 'circle',
+        startStyle: 'triangle',
+        endStyle: 'triangle',
         startConn,
         endConn,
       });

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -586,10 +586,10 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
                 m.attr('refX', 5)
                     .append('circle').attr('cx', 5).attr('cy', 5).attr('r', 3).attr('fill', color);
             } else if (style === 'arrow') {
-                m.attr('refX', 10)
+                m.attr('refX', start ? 10 : 0)
                     .append('path').attr('d', 'M0,0 L10,5 L0,10').attr('fill', 'none').attr('stroke', color).attr('stroke-width', 1.5);
             } else if (style === 'triangle') {
-                m.attr('refX', 9)
+                m.attr('refX', start ? 9 : 0)
                     .append('path').attr('d', 'M0,1 L9,5 L0,9 Z').attr('fill', color);
             }
         };

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -585,10 +585,10 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
                 m.attr('refX', 5)
                     .append('circle').attr('cx', 5).attr('cy', 5).attr('r', 3).attr('fill', color);
             } else if (style === 'arrow') {
-                m.attr('refX', start ? 0 : 10)
+                m.attr('refX', 10)
                     .append('path').attr('d', 'M0,0 L10,5 L0,10').attr('fill', 'none').attr('stroke', color).attr('stroke-width', 1.5);
             } else if (style === 'triangle') {
-                m.attr('refX', start ? 0 : 9)
+                m.attr('refX', 9)
                     .append('path').attr('d', 'M0,1 L9,5 L0,9 Z').attr('fill', color);
             }
         };

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -732,7 +732,8 @@ export function ensureConnectHandles(element: Selection<any, any, any, any>) {
     const bbox = (element.node() as SVGGraphicsElement).getBBox();
     const width = data.width ?? bbox.width;
     const height = data.height ?? bbox.height;
-    const { scaleX, scaleY } = data.transform ?? defaultTransform();
+    const transform = data.transform ?? defaultTransform();
+    const { scaleX, scaleY } = transform;
     const r = 4 / Math.max(scaleX, scaleY);
     const points = [
         { p: 'n', x: width / 2, y: 0 },
@@ -750,6 +751,8 @@ export function ensureConnectHandles(element: Selection<any, any, any, any>) {
             .attr('data-parent', data.id)
             .style('pointer-events', 'all')
             .style('fill', '#7fbbf7');
+        const abs = transformPoint(pt.x, pt.y, transform, { width, height });
+        h.attr('data-abs-x', abs.x).attr('data-abs-y', abs.y);
         h.call(
             d3.drag<SVGCircleElement, unknown>()
                 .on('start', function (event) {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -558,8 +558,7 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
         const common = {
             markerWidth: 10,
             markerHeight: 10,
-            refY: 5,
-            orient: 'auto'
+            refY: 5
         } as const;
         let startMarker: Selection<SVGMarkerElement, unknown, any, any> | null = null;
         let endMarker: Selection<SVGMarkerElement, unknown, any, any> | null = null;
@@ -569,7 +568,7 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
                 .attr('markerWidth', common.markerWidth)
                 .attr('markerHeight', common.markerHeight)
                 .attr('refY', common.refY)
-                .attr('orient', common.orient);
+                .attr('orient', 'auto-start-reverse');
         }
         if (hasEnd) {
             endMarker = defs.append('marker')
@@ -577,7 +576,7 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
                 .attr('markerWidth', common.markerWidth)
                 .attr('markerHeight', common.markerHeight)
                 .attr('refY', common.refY)
-                .attr('orient', common.orient);
+                .attr('orient', 'auto');
         }
 
         const drawShape = (m: Selection<SVGMarkerElement, unknown, any, any> | null, style: string, start: boolean) => {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -537,7 +537,7 @@ export function updateSelectedConnectionStyle(style: 'circle' | 'arrow' | 'trian
     }
 }
 
-function applyLineAppearance(element: Selection<SVGGElement, any, any, any>) {
+export function applyLineAppearance(element: Selection<SVGGElement, any, any, any>) {
     const data = element.datum() as any;
     const color = data.color ?? 'black';
     element.select('path').attr('stroke', color).attr('d', linePath(data));

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -558,10 +558,9 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
         const common = {
             markerWidth: 10,
             markerHeight: 10,
-            refX: 10,
             refY: 5,
             orient: 'auto'
-        } as any;
+        } as const;
         let startMarker: Selection<SVGMarkerElement, unknown, any, any> | null = null;
         let endMarker: Selection<SVGMarkerElement, unknown, any, any> | null = null;
         if (hasStart) {
@@ -569,32 +568,33 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
                 .attr('id', `${data.id}-start`)
                 .attr('markerWidth', common.markerWidth)
                 .attr('markerHeight', common.markerHeight)
-                .attr('refX', 0)
                 .attr('refY', common.refY)
-                .attr('orient', 'auto-start-reverse');
+                .attr('orient', common.orient);
         }
         if (hasEnd) {
             endMarker = defs.append('marker')
                 .attr('id', `${data.id}-end`)
                 .attr('markerWidth', common.markerWidth)
                 .attr('markerHeight', common.markerHeight)
-                .attr('refX', common.refX)
                 .attr('refY', common.refY)
                 .attr('orient', common.orient);
         }
 
-        const drawShape = (m: Selection<SVGMarkerElement, unknown, any, any> | null, style: string) => {
+        const drawShape = (m: Selection<SVGMarkerElement, unknown, any, any> | null, style: string, start: boolean) => {
             if (!m) return;
             if (style === 'circle') {
-                m.append('circle').attr('cx', 5).attr('cy', 5).attr('r', 3).attr('fill', color);
+                m.attr('refX', 5)
+                    .append('circle').attr('cx', 5).attr('cy', 5).attr('r', 3).attr('fill', color);
             } else if (style === 'arrow') {
-                m.append('path').attr('d', 'M0,0 L10,5 L0,10').attr('fill', 'none').attr('stroke', color).attr('stroke-width', 2);
+                m.attr('refX', 10)
+                    .append('path').attr('d', 'M0,0 L10,5 L0,10').attr('fill', 'none').attr('stroke', color).attr('stroke-width', 1.5);
             } else if (style === 'triangle') {
-                m.append('path').attr('d', 'M0,0 L10,5 L0,10 Z').attr('fill', color);
+                m.attr('refX', 9)
+                    .append('path').attr('d', 'M0,1 L9,5 L0,9 Z').attr('fill', color);
             }
         };
-        drawShape(startMarker, data.startStyle);
-        drawShape(endMarker, data.endStyle);
+        drawShape(startMarker, data.startStyle, true);
+        drawShape(endMarker, data.endStyle, false);
         element.select('path')
             .attr('marker-start', hasStart ? `url(#${data.id}-start)` : null)
             .attr('marker-end', hasEnd ? `url(#${data.id}-end)` : null);

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -586,10 +586,10 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
                 m.attr('refX', 5)
                     .append('circle').attr('cx', 5).attr('cy', 5).attr('r', 3).attr('fill', color);
             } else if (style === 'arrow') {
-                m.attr('refX', start ? 10 : 0)
+                m.attr('refX', start ? 0 : 10)
                     .append('path').attr('d', 'M0,0 L10,5 L0,10').attr('fill', 'none').attr('stroke', color).attr('stroke-width', 1.5);
             } else if (style === 'triangle') {
-                m.attr('refX', start ? 9 : 0)
+                m.attr('refX', start ? 0 : 9)
                     .append('path').attr('d', 'M0,1 L9,5 L0,9 Z').attr('fill', color);
             }
         };

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,7 +9,6 @@ const theme = createTheme({
 });
 
 export const noteColors = [
-    "#000000",
     "#8CB369",
     "#F4E285",
     "#F4A259",
@@ -17,6 +16,9 @@ export const noteColors = [
     "#BC4B51",
     "#168AAD",
     "#FF9B85",
+    "#000000",
 ];
+
+export const defaultLineColor = "#000000";
 
 export default theme;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,6 +9,7 @@ const theme = createTheme({
 });
 
 export const noteColors = [
+    "#000000",
     "#8CB369",
     "#F4E285",
     "#F4A259",


### PR DESCRIPTION
## Summary
- add ability to insert simple lines
- document new line shortcut in help dialog and README
- show a menu button for creating lines
- display connection handles on selected elements

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859bec8f9cc832ea3a2c10ac6f6b518