### PR TITLE
Add brush color menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ https://sergej-popov.github.io/tremolo/
 - Change sticky note text alignment using the header buttons when a note is selected.
 - Set a fixed font size for a sticky note from the header dropdown or choose "Auto" for automatic sizing (6–48px in even steps).
 - When brush mode is active a dropdown sets stroke thickness, or choose "Auto" for pressure-based width.
+- When brush mode is active a dropdown also lets you pick a stroke colour from the sticky note palette.
 - Toggle debug mode with **d** to show extra info, crosses over elements, and a debug panel with coordinates and rotation angles.
 - Press **/** or **?** or use the floating question icon to see a help dialog with all shortcuts.
 - Click the **export icon** or press **Ctrl+S** to export the current board as a **PNG** image with 40 px padding around the visible area.

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -42,6 +42,8 @@ const Menu: React.FC = () => {
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
   const brushWidth = app?.brushWidth ?? 'auto';
   const setBrushWidth = app?.setBrushWidth ?? (() => {});
+  const brushColor = app?.brushColor ?? defaultLineColor;
+  const setBrushColor = app?.setBrushColor ?? (() => {});
   const [fontSize, setFontSize] = React.useState<string>('auto');
   const [codeSize, setCodeSize] = React.useState<number>(codeFontSize);
   const [lineStyle, setLineStyle] = React.useState<'direct' | 'arc' | 'corner'>('arc');
@@ -334,6 +336,24 @@ const Menu: React.FC = () => {
               <MenuItem value="auto">Auto</MenuItem>
               {Array.from({ length: 8 }, (_, i) => i + 1).map((n) => (
                 <MenuItem key={n} value={n.toString()}>{`${n}px`}</MenuItem>
+              ))}
+            </Select>
+          </Box>
+        )}
+        {drawingMode && (
+          <Box id="brush-color-select" sx={{ mr: 2 }}>
+            <Select
+              size="small"
+              value={brushColor}
+              onChange={(e) => {
+                const c = e.target.value as string;
+                setBrushColor(c);
+              }}
+            >
+              {noteColors.map((c) => (
+                <MenuItem value={c} key={c}>
+                  <Box sx={{ width: 20, height: 20, backgroundColor: c }} />
+                </MenuItem>
               ))}
             </Select>
           </Box>

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -31,6 +31,8 @@ interface AppState {
   setDrawingMode: React.Dispatch<React.SetStateAction<boolean>>;
   brushWidth: number | 'auto';
   setBrushWidth: React.Dispatch<React.SetStateAction<number | 'auto'>>;
+  brushColor: string;
+  setBrushColor: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const AppContext = createContext<AppState | undefined>(undefined);
@@ -51,6 +53,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
   const [brushWidth, setBrushWidth] = useState<number | 'auto'>('auto');
+  const [brushColor, setBrushColor] = useState<string>(noteColors[noteColors.length - 1]);
 
   const addBoard = () => {
     setBoards((ids) => [...ids, ids.length ? Math.max(...ids) + 1 : 0]);
@@ -72,6 +75,18 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   React.useEffect(() => {
     setDebugMode(debug);
   }, [debug]);
+
+  React.useEffect(() => {
+    const disable = () => setDrawingMode(false);
+    window.addEventListener('createsticky', disable as EventListener);
+    window.addEventListener('createcodeblock', disable as EventListener);
+    window.addEventListener('createline', disable as EventListener);
+    return () => {
+      window.removeEventListener('createsticky', disable as EventListener);
+      window.removeEventListener('createcodeblock', disable as EventListener);
+      window.removeEventListener('createline', disable as EventListener);
+    };
+  }, []);
 
   return (
     <AppContext.Provider value={{
@@ -102,6 +117,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setDrawingMode,
       brushWidth,
       setBrushWidth,
+      brushColor,
+      setBrushColor,
     }}>
       {children}
     </AppContext.Provider>

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -83,6 +83,7 @@ const GuitarBoard: React.FC = () => {
   const codeFontSize = app?.codeFontSize ?? 14;
   const drawingMode = app?.drawingMode ?? false;
   const brushWidth = app?.brushWidth ?? 'auto';
+  const brushColor = app?.brushColor ?? defaultLineColor;
   const svgRef = useRef<SVGSVGElement | null>(null);
   const workspaceRef = useRef<SVGGElement | null>(null);
   const boardRef = useRef<SVGGElement | null>(null);
@@ -700,18 +701,19 @@ const GuitarBoard: React.FC = () => {
       const layer = svg.select<SVGGElement>('.drawings');
       const g = layer.append('g')
         .attr('class', 'drawing')
-        .datum<{ id: string; type: 'drawing'; width: number; height: number; transform: any; lines: any[] }>({
+        .datum<{ id: string; type: 'drawing'; width: number; height: number; transform: any; lines: any[]; color: string }>({
           id: info.data.id ?? generateId(),
           type: 'drawing',
           width: info.data.width,
           height: info.data.height,
           transform: { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 },
-          lines: info.data.lines.map((ln: any) => ({ ...ln }))
+          lines: info.data.lines.map((ln: any) => ({ ...ln })),
+          color: info.data.color ?? '#000000'
         });
       info.data.lines.forEach((ln: any) => {
         g.append('path')
           .attr('d', `M ${ln.x1} ${ln.y1} Q ${ln.cx} ${ln.cy} ${ln.x2} ${ln.y2}`)
-          .attr('stroke', 'black')
+          .attr('stroke', info.data.color ?? '#000000')
           .attr('fill', 'none')
           .attr('stroke-linecap', 'round')
           .attr('stroke-linejoin', 'round')
@@ -1199,13 +1201,14 @@ const GuitarBoard: React.FC = () => {
     const layer = svg.select<SVGGElement>('.drawings');
     const g = layer.append('g')
       .attr('class', 'drawing')
-      .datum<{ id: string; type: 'drawing'; width: number; height: number; transform: any; lines: any[] }>({
+      .datum<{ id: string; type: 'drawing'; width: number; height: number; transform: any; lines: any[]; color: string }>({
         id: generateId(),
         type: 'drawing',
         width: 0,
         height: 0,
         transform: { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 },
         lines: [],
+        color: brushColor,
       });
     drawingSel.current = g;
     drawing.current = true;
@@ -1243,7 +1246,7 @@ const GuitarBoard: React.FC = () => {
     const midY = (prev.y + sy) / 2;
     drawingSel.current.append('path')
       .attr('d', `M ${midPrev.x} ${midPrev.y} Q ${prev.x} ${prev.y} ${midX} ${midY}`)
-      .attr('stroke', 'black')
+      .attr('stroke', brushColor)
       .attr('fill', 'none')
       .attr('stroke-linecap', 'round')
       .attr('stroke-linejoin', 'round')
@@ -1259,6 +1262,7 @@ const GuitarBoard: React.FC = () => {
     const g = drawingSel.current;
     const bbox = (g.node() as SVGGraphicsElement).getBBox();
     const data: any = g.datum();
+    data.color = brushColor;
     data.width = bbox.width;
     data.height = bbox.height;
     data.lines = data.lines.map((ln: any) => ({


### PR DESCRIPTION
## Summary
- allow choosing brush colour from palette
- store colour with drawing data
- auto-disable drawing mode when other tools are used

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685dcceb88b4832e8905dc815b5520e2