### PR TITLE
Add audio paste support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://sergej-popov.github.io/tremolo/
 - Add multiple guitar boards in the same workspace.
 - Paste images that can be positioned and resized.
 - Paste YouTube links to embed videos while preserving aspect ratio.
+- Paste links to audio files to add playback controls.
 - Paste text to create sticky notes that can be dragged, resized and rotated. Double-click a sticky note to edit its text, or press **n** or use the toolbar button to insert an empty note.
 - Sticky note text wraps and shrinks automatically; if it still overflows at the minimum size, a thin scrollbar appears.
 - Scrollbars have a transparent track and respond to the mouse wheel when hovering over a sticky note.

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -612,7 +612,7 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
 
 
 export interface ElementCopy {
-    type: 'image' | 'video' | 'sticky' | 'board' | 'drawing' | 'code' | 'line' | 'meta';
+    type: 'image' | 'video' | 'audio' | 'sticky' | 'board' | 'drawing' | 'code' | 'line' | 'meta';
     data: any;
 }
 
@@ -621,6 +621,7 @@ export function getSelectedElementData(): ElementCopy | null {
     let type: ElementCopy['type'] | null = null;
     if (selectedElement.classed('pasted-image')) type = 'image';
     else if (selectedElement.classed('embedded-video')) type = 'video';
+    else if (selectedElement.classed('embedded-audio')) type = 'audio';
     else if (selectedElement.classed('sticky-note')) type = 'sticky';
     else if (selectedElement.classed('code-block')) type = 'code';
     else if (selectedElement.classed('guitar-board')) type = 'board';


### PR DESCRIPTION
## Summary
- support audio paste with draggable player
- save/load audio elements
- list audio in README features

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68600a6410bc832e9d0fb324eacc4db8