### PR TITLE
Add frame tool for grouping workspace elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://sergej-popov.github.io/tremolo/
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Toolbar buttons add items at the cursor unless the cursor is outside the workspace, in which case they appear in the centre of the screen.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
-- Toggle the frame tool to draw resizable frames with customizable background colors that move every element contained inside when repositioned, making it easy to group layouts on the board.
+- Toggle the frame tool to draw resizable frames with customizable background colors and border styles (solid, dashed, or dotted) that move every element contained inside when repositioned, making it easy to group layouts on the board.
 - Draw lines with straight, arched or cornered style. New lines start arched with triangle connectors and snap to subtle connectors at each element's side, remaining attached when those elements move.
 - Double-click a line to add a label that stays centred as the line moves. Lyric/video connectors show the current video time in `m:ss` on the label.
 - Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none. Lines default to black.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ https://sergej-popov.github.io/tremolo/
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Toolbar buttons add items at the cursor unless the cursor is outside the workspace, in which case they appear in the centre of the screen.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
+- Toggle the frame tool to draw resizable frames that move every element contained inside when repositioned, making it easy to group layouts on the board.
 - Draw lines with straight, arched or cornered style. New lines start arched with triangle connectors and snap to subtle connectors at each element's side, remaining attached when those elements move.
 - Double-click a line to add a label that stays centred as the line moves. Lyric/video connectors show the current video time in `m:ss` on the label.
 - Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none. Lines default to black.
@@ -60,6 +61,7 @@ https://sergej-popov.github.io/tremolo/
 
 ### Tools
 - **b** – toggle the brush drawing mode.
+- **f** – toggle the frame tool for drawing frames.
 - **n** – insert a sticky note.
 - **c** – insert a code block.
 - **l** – insert a line.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://sergej-popov.github.io/tremolo/
 - Insert code blocks with syntax highlighting. When a code block is selected dropdowns in the header change its language, theme and font size. Only GitHub light and dark themes are available.
 - Toolbar buttons add items at the cursor unless the cursor is outside the workspace, in which case they appear in the centre of the screen.
 - Use the brush tool to draw very smooth strokes that get thicker as you draw slower. A dropdown lets you set a fixed stroke width instead of pressure. Drawings can be moved, resized and rotated.
-- Toggle the frame tool to draw resizable frames that move every element contained inside when repositioned, making it easy to group layouts on the board.
+- Toggle the frame tool to draw resizable frames with customizable background colors that move every element contained inside when repositioned, making it easy to group layouts on the board.
 - Draw lines with straight, arched or cornered style. New lines start arched with triangle connectors and snap to subtle connectors at each element's side, remaining attached when those elements move.
 - Double-click a line to add a label that stays centred as the line moves. Lyric/video connectors show the current video time in `m:ss` on the label.
 - Change a line's colour from the sticky note palette (now including black) and set the start and end connection style independently: circle, arrow, filled triangle or none. Lines default to black.

--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -28,6 +28,7 @@ const shortcuts: ShortcutSection[] = [
     title: 'Tools',
     items: [
       { key: 'b', action: 'Toggle brush drawing mode' },
+      { key: 'f', action: 'Toggle frame tool' },
       { key: 'n', action: 'Insert sticky note' },
       { key: 'c', action: 'Insert code block' },
       { key: 'l', action: 'Insert line' },

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -15,6 +15,7 @@ import BrushIcon from '@mui/icons-material/Brush';
 import CodeIcon from '@mui/icons-material/Code';
 import StickyNote2Icon from '@mui/icons-material/StickyNote2';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
+import CropSquareIcon from '@mui/icons-material/CropSquare';
 import SaveIcon from '@mui/icons-material/Save';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
@@ -43,6 +44,8 @@ const Menu: React.FC = () => {
   const addBoard = app?.addBoard ?? (() => {});
   const drawingMode = app?.drawingMode ?? false;
   const setDrawingMode = app?.setDrawingMode ?? (() => {});
+  const frameMode = app?.frameMode ?? false;
+  const setFrameMode = app?.setFrameMode ?? (() => {});
   const brushWidth = app?.brushWidth ?? 'auto';
   const setBrushWidth = app?.setBrushWidth ?? (() => {});
   const brushColor = app?.brushColor ?? defaultLineColor;
@@ -123,10 +126,33 @@ const Menu: React.FC = () => {
           <Typography variant="h6" component="div" sx={{ mr: 2 }}>
             Tremolo
           </Typography>
+          <IconButton
+            color={frameMode ? 'secondary' : 'inherit'}
+            onClick={() => {
+              const next = !frameMode;
+              setFrameMode(next);
+              if (next) {
+                setDrawingMode(false);
+              }
+            }}
+            sx={{ mr: 1 }}
+          >
+            <CropSquareIcon />
+          </IconButton>
           <IconButton size="large" color="inherit" onClick={() => window.dispatchEvent(new Event('createboard'))} sx={{ mr: 1 }}>
             <MusicNoteIcon />
           </IconButton>
-          <IconButton color={drawingMode ? 'secondary' : 'inherit'} onClick={() => setDrawingMode(!drawingMode)} sx={{ mr: 1 }}>
+          <IconButton
+            color={drawingMode ? 'secondary' : 'inherit'}
+            onClick={() => {
+              const next = !drawingMode;
+              setDrawingMode(next);
+              if (next) {
+                setFrameMode(false);
+              }
+            }}
+            sx={{ mr: 1 }}
+          >
             <BrushIcon />
           </IconButton>
           <IconButton color="inherit" onClick={() => window.dispatchEvent(new Event('createline'))} sx={{ mr: 1 }}>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -7,7 +7,7 @@ import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import { AppContext } from './Store';
 import { noteColors, defaultLineColor } from './theme';
-import { updateSelectedColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, highlightLangs, highlightThemes } from './d3-ext';
+import { updateSelectedColor, updateSelectedFrameColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
@@ -25,14 +25,18 @@ import UndoIcon from '@mui/icons-material/Undo';
 import RedoIcon from '@mui/icons-material/Redo';
 const codeLanguages = highlightLangs as readonly string[];
 const codeThemes = highlightThemes as readonly string[];
+const frameColors = ['#ffffff', ...noteColors.filter((c) => c.toLowerCase() !== '#ffffff')];
 
 const Menu: React.FC = () => {
   const app = useContext(AppContext);
   const stickyColor = app?.stickyColor ?? noteColors[0];
   const setStickyColor = app?.setStickyColor ?? (() => {});
+  const frameColor = app?.frameColor ?? '#ffffff';
+  const setFrameColor = app?.setFrameColor ?? (() => {});
   const stickyAlign = app?.stickyAlign ?? 'center';
   const setStickyAlign = app?.setStickyAlign ?? (() => {});
   const stickySelected = app?.stickySelected ?? false;
+  const frameSelected = app?.frameSelected ?? false;
   const codeSelected = app?.codeSelected ?? false;
   const boardSelected = app?.boardSelected ?? false;
   const codeLanguage = app?.codeLanguage ?? 'typescript';
@@ -184,6 +188,26 @@ const Menu: React.FC = () => {
           >
             <EditNoteIcon />
           </IconButton>
+        )}
+        {frameSelected && (
+          <Box id="frame-color-select" sx={{ mr: 2 }}>
+            <Select
+              size="small"
+              value={frameColor}
+              onChange={(e) => {
+                const color = e.target.value as string;
+                setFrameColor(color);
+                updateSelectedFrameColor(color);
+                pushHistory(getSnapshot(), 'frame', 'style');
+              }}
+            >
+              {frameColors.map((c) => (
+                <MenuItem value={c} key={c}>
+                  <Box sx={{ width: 20, height: 20, backgroundColor: c, border: '1px solid rgba(0,0,0,0.2)' }} />
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
         )}
         {stickySelected && (
           <>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -6,8 +6,9 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import { AppContext } from './Store';
+import type { FrameLineStyle } from './Store';
 import { noteColors, defaultLineColor } from './theme';
-import { updateSelectedColor, updateSelectedFrameColor, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, highlightLangs, highlightThemes } from './d3-ext';
+import { updateSelectedColor, updateSelectedFrameColor, updateSelectedFrameLineStyle, updateSelectedAlignment, updateSelectedFontSize, updateSelectedCodeLang, updateSelectedCodeTheme, updateSelectedCodeFontSize, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, highlightLangs, highlightThemes } from './d3-ext';
 import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
@@ -33,6 +34,8 @@ const Menu: React.FC = () => {
   const setStickyColor = app?.setStickyColor ?? (() => {});
   const frameColor = app?.frameColor ?? '#ffffff';
   const setFrameColor = app?.setFrameColor ?? (() => {});
+  const frameLineStyle = app?.frameLineStyle ?? 'solid';
+  const setFrameLineStyle = app?.setFrameLineStyle ?? (() => {});
   const stickyAlign = app?.stickyAlign ?? 'center';
   const setStickyAlign = app?.setStickyAlign ?? (() => {});
   const stickySelected = app?.stickySelected ?? false;
@@ -206,6 +209,25 @@ const Menu: React.FC = () => {
                   <Box sx={{ width: 20, height: 20, backgroundColor: c, border: '1px solid rgba(0,0,0,0.2)' }} />
                 </MenuItem>
               ))}
+            </Select>
+          </Box>
+        )}
+        {frameSelected && (
+          <Box id="frame-line-style-select" sx={{ mr: 2 }}>
+            <Select
+              size="small"
+              value={frameLineStyle}
+              onChange={(e) => {
+                const style = e.target.value as FrameLineStyle;
+                if (style === frameLineStyle) return;
+                setFrameLineStyle(style);
+                updateSelectedFrameLineStyle(style);
+                pushHistory(getSnapshot(), 'frame', 'style');
+              }}
+            >
+              <MenuItem value="solid">Solid</MenuItem>
+              <MenuItem value="dashed">Dashed</MenuItem>
+              <MenuItem value="dotted">Dotted</MenuItem>
             </Select>
           </Box>
         )}

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -35,6 +35,8 @@ interface AppState {
   setDebug: React.Dispatch<React.SetStateAction<boolean>>;
   drawingMode: boolean;
   setDrawingMode: React.Dispatch<React.SetStateAction<boolean>>;
+  frameMode: boolean;
+  setFrameMode: React.Dispatch<React.SetStateAction<boolean>>;
   brushWidth: number | 'auto';
   setBrushWidth: React.Dispatch<React.SetStateAction<number | 'auto'>>;
   brushColor: string;
@@ -67,6 +69,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [boardSelected, setBoardSelected] = useState<boolean>(false);
   const [debug, setDebug] = useState<boolean>(false);
   const [drawingMode, setDrawingMode] = useState<boolean>(false);
+  const [frameMode, setFrameMode] = useState<boolean>(false);
   const [brushWidth, setBrushWidth] = useState<number | 'auto'>('auto');
   const [brushColor, setBrushColor] = useState<string>(noteColors[noteColors.length - 1]);
 
@@ -143,7 +146,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
         return;
       }
       if (e.key === 'b') {
+        setFrameMode(false);
         setDrawingMode((prev) => !prev);
+      }
+      if (e.key === 'f') {
+        setDrawingMode(false);
+        setFrameMode((prev) => !prev);
       }
     };
     window.addEventListener('keydown', handler);
@@ -163,6 +171,20 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       window.removeEventListener('createsticky', disable as EventListener);
       window.removeEventListener('createcodeblock', disable as EventListener);
       window.removeEventListener('createline', disable as EventListener);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    const disable = () => setFrameMode(false);
+    window.addEventListener('createsticky', disable as EventListener);
+    window.addEventListener('createcodeblock', disable as EventListener);
+    window.addEventListener('createline', disable as EventListener);
+    window.addEventListener('createboard', disable as EventListener);
+    return () => {
+      window.removeEventListener('createsticky', disable as EventListener);
+      window.removeEventListener('createcodeblock', disable as EventListener);
+      window.removeEventListener('createline', disable as EventListener);
+      window.removeEventListener('createboard', disable as EventListener);
     };
   }, []);
 
@@ -216,6 +238,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setDebug,
       drawingMode,
       setDrawingMode,
+      frameMode,
+      setFrameMode,
       brushWidth,
       setBrushWidth,
       brushColor,

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -3,6 +3,8 @@ import { setDebugMode } from './d3-ext';
 
 import { noteColors } from "./theme";
 
+export type FrameLineStyle = 'solid' | 'dashed' | 'dotted';
+
 export interface HistoryEntry {
   state: string;
   type?: string;
@@ -16,6 +18,8 @@ interface AppState {
   setStickyColor: React.Dispatch<React.SetStateAction<string>>;
   frameColor: string;
   setFrameColor: React.Dispatch<React.SetStateAction<string>>;
+  frameLineStyle: FrameLineStyle;
+  setFrameLineStyle: React.Dispatch<React.SetStateAction<FrameLineStyle>>;
   stickyAlign: 'left' | 'center' | 'right';
   setStickyAlign: React.Dispatch<React.SetStateAction<'left' | 'center' | 'right'>>;
   stickySelected: boolean;
@@ -64,6 +68,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [data, setData] = useState<any[]>([]);
   const [stickyColor, setStickyColor] = useState<string>(noteColors[0]);
   const [frameColor, setFrameColor] = useState<string>('#ffffff');
+  const [frameLineStyle, setFrameLineStyle] = useState<FrameLineStyle>('solid');
   const [stickyAlign, setStickyAlign] = useState<'left' | 'center' | 'right'>('center');
   const [stickySelected, setStickySelected] = useState<boolean>(false);
   const [frameSelected, setFrameSelected] = useState<boolean>(false);
@@ -225,6 +230,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setStickyColor,
       frameColor,
       setFrameColor,
+      frameLineStyle,
+      setFrameLineStyle,
       stickyAlign,
       setStickyAlign,
       stickySelected,

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -14,10 +14,14 @@ interface AppState {
   setData: React.Dispatch<React.SetStateAction<any[]>>;
   stickyColor: string;
   setStickyColor: React.Dispatch<React.SetStateAction<string>>;
+  frameColor: string;
+  setFrameColor: React.Dispatch<React.SetStateAction<string>>;
   stickyAlign: 'left' | 'center' | 'right';
   setStickyAlign: React.Dispatch<React.SetStateAction<'left' | 'center' | 'right'>>;
   stickySelected: boolean;
   setStickySelected: React.Dispatch<React.SetStateAction<boolean>>;
+  frameSelected: boolean;
+  setFrameSelected: React.Dispatch<React.SetStateAction<boolean>>;
   codeSelected: boolean;
   setCodeSelected: React.Dispatch<React.SetStateAction<boolean>>;
   codeLanguage: string;
@@ -59,8 +63,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const [data, setData] = useState<any[]>([]);
   const [stickyColor, setStickyColor] = useState<string>(noteColors[0]);
+  const [frameColor, setFrameColor] = useState<string>('#ffffff');
   const [stickyAlign, setStickyAlign] = useState<'left' | 'center' | 'right'>('center');
   const [stickySelected, setStickySelected] = useState<boolean>(false);
+  const [frameSelected, setFrameSelected] = useState<boolean>(false);
   const [codeSelected, setCodeSelected] = useState<boolean>(false);
   const [codeLanguage, setCodeLanguage] = useState<string>('typescript');
   const [codeTheme, setCodeTheme] = useState<string>('github-dark');
@@ -217,10 +223,14 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       setData,
       stickyColor,
       setStickyColor,
+      frameColor,
+      setFrameColor,
       stickyAlign,
       setStickyAlign,
       stickySelected,
       setStickySelected,
+      frameSelected,
+      setFrameSelected,
       codeSelected,
       setCodeSelected,
       codeLanguage,

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -169,6 +169,7 @@ const GuitarBoard: React.FC = () => {
 
   const frameSel = useRef<d3.Selection<SVGGElement, any, any, any> | null>(null);
   const frameStart = useRef<{ x: number; y: number } | null>(null);
+  const redirectedPointerTargetsRef = useRef<Map<number, Element>>(new Map());
 
   const pendingRef = useRef<{ state: ElementCopy[]; type?: string; action?: string } | null>(null);
 
@@ -475,6 +476,38 @@ const GuitarBoard: React.FC = () => {
     return group;
   };
 
+  const dispatchRedirectedPointerEvent = useCallback((source: PointerEvent, target: Element) => {
+    const pointerInit: PointerEventInit = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      pointerId: source.pointerId,
+      pointerType: source.pointerType,
+      button: source.button,
+      buttons: source.buttons,
+      clientX: source.clientX,
+      clientY: source.clientY,
+      pageX: source.pageX,
+      pageY: source.pageY,
+      screenX: source.screenX,
+      screenY: source.screenY,
+      ctrlKey: source.ctrlKey,
+      shiftKey: source.shiftKey,
+      altKey: source.altKey,
+      metaKey: source.metaKey,
+      pressure: source.pressure,
+      tangentialPressure: source.tangentialPressure,
+      width: source.width,
+      height: source.height,
+      tiltX: source.tiltX,
+      tiltY: source.tiltY,
+      twist: source.twist,
+      isPrimary: source.isPrimary,
+    };
+
+    target.dispatchEvent(new PointerEvent(source.type, pointerInit));
+  }, []);
+
   const handleFramePointerDown = useCallback((event: PointerEvent) => {
     const target = event.currentTarget as SVGRectElement | null;
     if (!target) return;
@@ -488,34 +521,69 @@ const GuitarBoard: React.FC = () => {
     const redirectTarget = underlying.closest(interactiveElementSelector) as Element | null;
     if (!redirectTarget || redirectTarget === frameGroup) return;
 
-    const pointerInit: PointerEventInit = {
-      bubbles: true,
-      cancelable: true,
-      pointerId: event.pointerId,
-      pointerType: event.pointerType,
-      button: event.button,
-      buttons: event.buttons,
-      clientX: event.clientX,
-      clientY: event.clientY,
-      ctrlKey: event.ctrlKey,
-      shiftKey: event.shiftKey,
-      altKey: event.altKey,
-      metaKey: event.metaKey,
-      pressure: event.pressure,
-      tangentialPressure: event.tangentialPressure,
-      width: event.width,
-      height: event.height,
-      tiltX: event.tiltX,
-      tiltY: event.tiltY,
-      twist: event.twist,
-      isPrimary: event.isPrimary,
-    };
-
-    redirectTarget.dispatchEvent(new PointerEvent(event.type, pointerInit));
+    redirectedPointerTargetsRef.current.set(event.pointerId, redirectTarget);
+    if (typeof target.setPointerCapture === 'function') {
+      try {
+        target.setPointerCapture(event.pointerId);
+      } catch {
+        // ignore capture failures
+      }
+    }
+    dispatchRedirectedPointerEvent(event, redirectTarget);
     event.preventDefault();
     event.stopImmediatePropagation();
     event.stopPropagation();
-  }, []);
+  }, [dispatchRedirectedPointerEvent]);
+
+  const handleFramePointerMove = useCallback((event: PointerEvent) => {
+    const redirectTarget = redirectedPointerTargetsRef.current.get(event.pointerId);
+    if (!redirectTarget) return;
+    dispatchRedirectedPointerEvent(event, redirectTarget);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+  }, [dispatchRedirectedPointerEvent]);
+
+  const finishRedirectedPointer = useCallback((event: PointerEvent) => {
+    const target = event.currentTarget as SVGRectElement | null;
+    const captureTarget = target as (Element & {
+      releasePointerCapture?: (pointerId: number) => void;
+      hasPointerCapture?: (pointerId: number) => boolean;
+    }) | null;
+    if (
+      captureTarget &&
+      typeof captureTarget.releasePointerCapture === 'function' &&
+      captureTarget.hasPointerCapture?.(event.pointerId)
+    ) {
+      try {
+        captureTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // ignore release failures
+      }
+    }
+    const redirectTarget = redirectedPointerTargetsRef.current.get(event.pointerId);
+    if (!redirectTarget) {
+      redirectedPointerTargetsRef.current.delete(event.pointerId);
+      return false;
+    }
+    redirectedPointerTargetsRef.current.delete(event.pointerId);
+    dispatchRedirectedPointerEvent(event, redirectTarget);
+    return true;
+  }, [dispatchRedirectedPointerEvent]);
+
+  const handleFramePointerUp = useCallback((event: PointerEvent) => {
+    if (!finishRedirectedPointer(event)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+  }, [finishRedirectedPointer]);
+
+  const handleFramePointerCancel = useCallback((event: PointerEvent) => {
+    if (!finishRedirectedPointer(event)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+  }, [finishRedirectedPointer]);
 
   const createFrameGroup = useCallback((opts: { id?: string; width: number; height: number; transform: TransformValues; color?: string; autoSelect?: boolean }) => {
     const svg = d3.select(svgRef.current);
@@ -544,7 +612,10 @@ const GuitarBoard: React.FC = () => {
       .attr('stroke-width', 2)
       .attr('stroke-dasharray', '8 4')
       .style('cursor', 'move')
-      .on('pointerdown.frame-block', handleFramePointerDown);
+      .on('pointerdown.frame-block', handleFramePointerDown)
+      .on('pointermove.frame-block', handleFramePointerMove)
+      .on('pointerup.frame-block', handleFramePointerUp)
+      .on('pointercancel.frame-block', handleFramePointerCancel);
 
     applyTransform(group, transform);
     group.call(makeDraggable);
@@ -559,7 +630,14 @@ const GuitarBoard: React.FC = () => {
     }
 
     return group;
-  }, [debug, frameColor, handleFramePointerDown]);
+  }, [
+    debug,
+    frameColor,
+    handleFramePointerCancel,
+    handleFramePointerDown,
+    handleFramePointerMove,
+    handleFramePointerUp,
+  ]);
 
 
   const addSticky = useCallback((text: string, pos: { x: number, y: number }, opts: { fontSize?: number | null; color?: string; align?: 'left' | 'center' | 'right' } = {}) => {
@@ -1778,7 +1856,10 @@ const GuitarBoard: React.FC = () => {
         .attr('stroke-width', 2)
         .attr('stroke-dasharray', '8 4')
         .style('cursor', 'move')
-        .on('pointerdown.frame-block', handleFramePointerDown);
+        .on('pointerdown.frame-block', handleFramePointerDown)
+        .on('pointermove.frame-block', handleFramePointerMove)
+        .on('pointerup.frame-block', handleFramePointerUp)
+        .on('pointercancel.frame-block', handleFramePointerCancel);
       frameSel.current = group;
       frameStart.current = { x, y };
       event.currentTarget.setPointerCapture(event.pointerId);

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -71,6 +71,7 @@ const youtubeRegex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu
 
 const frameStrokeColor = '#4a90e2';
 const frameFillOpacity = 0.12;
+const interactiveElementSelector = '.pasted-image, .embedded-video, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board, .frame-element';
 
 function extractVideoId(url: string): string | null {
   const match = url.match(youtubeRegex);
@@ -474,6 +475,48 @@ const GuitarBoard: React.FC = () => {
     return group;
   };
 
+  const handleFramePointerDown = useCallback((event: PointerEvent) => {
+    const target = event.currentTarget as SVGRectElement | null;
+    if (!target) return;
+    const frameGroup = target.closest<SVGGElement>('.frame-element');
+    if (!frameGroup) return;
+    const previousPointerEvents = target.style.pointerEvents;
+    target.style.pointerEvents = 'none';
+    const underlying = document.elementFromPoint(event.clientX, event.clientY);
+    target.style.pointerEvents = previousPointerEvents;
+    if (!underlying) return;
+    const redirectTarget = underlying.closest(interactiveElementSelector) as Element | null;
+    if (!redirectTarget || redirectTarget === frameGroup) return;
+
+    const pointerInit: PointerEventInit = {
+      bubbles: true,
+      cancelable: true,
+      pointerId: event.pointerId,
+      pointerType: event.pointerType,
+      button: event.button,
+      buttons: event.buttons,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      metaKey: event.metaKey,
+      pressure: event.pressure,
+      tangentialPressure: event.tangentialPressure,
+      width: event.width,
+      height: event.height,
+      tiltX: event.tiltX,
+      tiltY: event.tiltY,
+      twist: event.twist,
+      isPrimary: event.isPrimary,
+    };
+
+    redirectTarget.dispatchEvent(new PointerEvent(event.type, pointerInit));
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+  }, []);
+
   const createFrameGroup = useCallback((opts: { id?: string; width: number; height: number; transform: TransformValues; color?: string; autoSelect?: boolean }) => {
     const svg = d3.select(svgRef.current);
     const layer = svg.select<SVGGElement>('.frames');
@@ -500,7 +543,8 @@ const GuitarBoard: React.FC = () => {
       .attr('stroke', frameStrokeColor)
       .attr('stroke-width', 2)
       .attr('stroke-dasharray', '8 4')
-      .style('cursor', 'move');
+      .style('cursor', 'move')
+      .on('pointerdown.frame-block', handleFramePointerDown);
 
     applyTransform(group, transform);
     group.call(makeDraggable);
@@ -515,7 +559,7 @@ const GuitarBoard: React.FC = () => {
     }
 
     return group;
-  }, [debug, frameColor]);
+  }, [debug, frameColor, handleFramePointerDown]);
 
 
   const addSticky = useCallback((text: string, pos: { x: number, y: number }, opts: { fontSize?: number | null; color?: string; align?: 'left' | 'center' | 'right' } = {}) => {
@@ -1733,7 +1777,8 @@ const GuitarBoard: React.FC = () => {
         .attr('stroke', frameStrokeColor)
         .attr('stroke-width', 2)
         .attr('stroke-dasharray', '8 4')
-        .style('cursor', 'move');
+        .style('cursor', 'move')
+        .on('pointerdown.frame-block', handleFramePointerDown);
       frameSel.current = group;
       frameStart.current = { x, y };
       event.currentTarget.setPointerCapture(event.pointerId);

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useContext, useCallback } from 'react';
 import * as d3 from 'd3';
-import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, applyLineAppearance } from '../d3-ext';
+import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, updateDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, updateSelectedCodeLang, updateSelectedCodeTheme, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineStyle, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, applyLineAppearance, TransformValues } from '../d3-ext';
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';
@@ -69,6 +69,8 @@ const audioPadding = 10;
 
 const youtubeRegex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]+)/;
 
+const frameStrokeColor = '#4a90e2';
+
 function extractVideoId(url: string): string | null {
   const match = url.match(youtubeRegex);
   return match ? match[1] : null;
@@ -112,6 +114,7 @@ const getElementType = (node: Element | null): string | undefined => {
   if (sel.classed('guitar-board')) return 'board';
   if (sel.classed('drawing')) return 'drawing';
   if (sel.classed('line-element')) return 'line';
+  if (sel.classed('frame-element')) return 'frame';
   return undefined;
 };
 
@@ -129,6 +132,7 @@ const GuitarBoard: React.FC = () => {
   const codeTheme = app?.codeTheme ?? 'github-dark';
   const codeFontSize = app?.codeFontSize ?? 14;
   const drawingMode = app?.drawingMode ?? false;
+  const frameMode = app?.frameMode ?? false;
   const brushWidth = app?.brushWidth ?? 'auto';
   const brushColor = app?.brushColor ?? defaultLineColor;
   const pushHistory = app?.pushHistory ?? (() => {});
@@ -156,6 +160,9 @@ const GuitarBoard: React.FC = () => {
   const lastPoint = useRef<{ x: number; y: number; time: number } | null>(null);
   const lastMid = useRef<{ x: number; y: number } | null>(null);
   const lastStroke = useRef<number>(typeof brushWidth === 'number' ? brushWidth : 4);
+
+  const frameSel = useRef<d3.Selection<SVGGElement, any, any, any> | null>(null);
+  const frameStart = useRef<{ x: number; y: number } | null>(null);
 
   const pendingRef = useRef<{ state: ElementCopy[]; type?: string; action?: string } | null>(null);
 
@@ -461,6 +468,47 @@ const GuitarBoard: React.FC = () => {
 
     return group;
   };
+
+  const createFrameGroup = useCallback((opts: { id?: string; width: number; height: number; transform: TransformValues; autoSelect?: boolean }) => {
+    const svg = d3.select(svgRef.current);
+    const layer = svg.select<SVGGElement>('.frames');
+    const transform = { ...opts.transform };
+    const group = layer.append('g')
+      .attr('class', 'frame-element')
+      .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues }>({
+        id: opts.id ?? generateId(),
+        type: 'frame',
+        width: opts.width,
+        height: opts.height,
+        transform,
+      });
+
+    group.append('rect')
+      .attr('class', 'frame-rect')
+      .attr('x', 0)
+      .attr('y', 0)
+      .attr('width', opts.width)
+      .attr('height', opts.height)
+      .attr('fill', 'transparent')
+      .attr('stroke', frameStrokeColor)
+      .attr('stroke-width', 2)
+      .attr('stroke-dasharray', '8 4')
+      .style('pointer-events', 'visibleStroke');
+
+    applyTransform(group, transform);
+    group.call(makeDraggable);
+    group.call(makeResizable, { lockAspectRatio: false });
+
+    if (debug) {
+      addDebugCross(group);
+    }
+
+    if (opts.autoSelect !== false) {
+      group.dispatch('click');
+    }
+
+    return group;
+  }, [debug]);
 
 
   const addSticky = useCallback((text: string, pos: { x: number, y: number }, opts: { fontSize?: number | null; color?: string; align?: 'left' | 'center' | 'right' } = {}) => {
@@ -987,6 +1035,18 @@ const GuitarBoard: React.FC = () => {
         }
       };
       apply();
+    } else if (info.type === 'frame') {
+      const width = info.data.width ?? 0;
+      const height = info.data.height ?? 0;
+      const baseTransform: TransformValues = info.data.transform ?? { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 };
+      const frame = createFrameGroup({
+        id: info.data.id,
+        width,
+        height,
+        transform: { ...baseTransform, translateX: pos.x, translateY: pos.y },
+      });
+      const d = frame.datum() as any;
+      d.id = info.data.id;
     } else if (info.type === 'line') {
       const g = addLine(
         { x: info.data.x1, y: info.data.y1 },
@@ -1042,12 +1102,12 @@ const GuitarBoard: React.FC = () => {
     const svg = d3.select(svgRef.current);
     const workspace = svg.select<SVGGElement>('.workspace');
     const items: ElementCopy[] = [];
-    const selector = '.pasted-image, .embedded-video, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board';
+    const selector = '.pasted-image, .embedded-video, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board, .frame-element';
     workspace.selectAll<SVGGElement, any>(selector).each(function () {
       const el = d3.select(this);
       const data = { ...(el.datum() as any) };
       if (!data || !data.type) return;
-      if (!['image','video','audio','sticky','board','drawing','code','line'].includes(data.type)) return;
+      if (!['image','video','audio','sticky','board','drawing','code','line','frame'].includes(data.type)) return;
       const info: ElementCopy = { type: data.type, data: { ...data } };
       if (info.type === 'board') {
         info.data.notes = el.selectAll('.note').data().map((n: any) => ({ string: n.string, fret: n.fret }));
@@ -1095,7 +1155,7 @@ const GuitarBoard: React.FC = () => {
       });
       workspace
         .selectAll(
-          '.pasted-image, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board'
+          '.pasted-image, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board, .frame-element'
         )
         .remove();
     } else {
@@ -1446,15 +1506,15 @@ const GuitarBoard: React.FC = () => {
         if (event.type === 'dblclick') return false;
         const e = event as any;
         if (e.ctrlKey) return false;
-        if (drawingMode) return false;
+        if (drawingMode || frameMode) return false;
         const target = e.target as Element;
         return target === svgRef.current || target === workspaceRef.current;
       });
     }
     if (workspaceRef.current) {
-      d3.select(workspaceRef.current).style('pointer-events', drawingMode ? 'none' : 'all');
+      d3.select(workspaceRef.current).style('pointer-events', drawingMode || frameMode ? 'none' : 'all');
     }
-  }, [drawingMode]);
+  }, [drawingMode, frameMode]);
 
   useEffect(() => {
     setStickySelected(false);
@@ -1625,6 +1685,37 @@ const GuitarBoard: React.FC = () => {
   };
 
   const handlePointerDown = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (frameMode) {
+      event.stopPropagation();
+      pushHistory(serializeWorkspace(), 'frame', 'create');
+      const { x, y } = toWorkspace(event.clientX, event.clientY);
+      const svg = d3.select(svgRef.current);
+      const layer = svg.select<SVGGElement>('.frames');
+      const group = layer.append('g')
+        .attr('class', 'frame-element')
+        .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues }>({
+          id: generateId(),
+          type: 'frame',
+          width: 0,
+          height: 0,
+          transform: { translateX: x, translateY: y, scaleX: 1, scaleY: 1, rotate: 0 },
+        });
+      group.append('rect')
+        .attr('class', 'frame-rect')
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('width', 0)
+        .attr('height', 0)
+        .attr('fill', 'transparent')
+        .attr('stroke', frameStrokeColor)
+        .attr('stroke-width', 2)
+        .attr('stroke-dasharray', '8 4')
+        .style('pointer-events', 'visibleStroke');
+      frameSel.current = group;
+      frameStart.current = { x, y };
+      event.currentTarget.setPointerCapture(event.pointerId);
+      return;
+    }
     if (!drawingMode) return;
     event.stopPropagation();
     pushHistory(serializeWorkspace(), 'drawing', 'create');
@@ -1651,6 +1742,25 @@ const GuitarBoard: React.FC = () => {
   };
 
   const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (frameSel.current && frameStart.current) {
+      const { x, y } = toWorkspace(event.clientX, event.clientY);
+      const start = frameStart.current;
+      const left = Math.min(start.x, x);
+      const top = Math.min(start.y, y);
+      const width = Math.max(0, Math.abs(x - start.x));
+      const height = Math.max(0, Math.abs(y - start.y));
+      const group = frameSel.current;
+      const data: any = group.datum();
+      data.width = width;
+      data.height = height;
+      const transform: TransformValues = { translateX: left, translateY: top, scaleX: 1, scaleY: 1, rotate: 0 };
+      data.transform = transform;
+      group.select<SVGRectElement>('rect.frame-rect')
+        .attr('width', width)
+        .attr('height', height);
+      applyTransform(group as any, transform);
+      return;
+    }
     if (!drawing.current || !drawingSel.current) return;
     const prev = lastPoint.current;
     const midPrev = lastMid.current;
@@ -1721,6 +1831,22 @@ const GuitarBoard: React.FC = () => {
   };
 
   const handlePointerUp = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (frameSel.current) {
+      const group = frameSel.current;
+      const data: any = group.datum();
+      if (!data || data.width < 5 || data.height < 5) {
+        group.remove();
+      } else {
+        group.call(makeDraggable);
+        group.call(makeResizable, { lockAspectRatio: false });
+        if (debug) addDebugCross(group);
+        group.dispatch('click');
+      }
+      frameSel.current = null;
+      frameStart.current = null;
+      event.currentTarget.releasePointerCapture(event.pointerId);
+      return;
+    }
     if (!drawing.current) return;
     finishDrawing();
     event.currentTarget.releasePointerCapture(event.pointerId);
@@ -1736,6 +1862,7 @@ const GuitarBoard: React.FC = () => {
       workspace.append('g').attr('class', 'embedded-audios');
       workspace.append('g').attr('class', 'sticky-notes');
       workspace.append('g').attr('class', 'code-blocks');
+      workspace.append('g').attr('class', 'frames');
       workspace.append('g').attr('class', 'lines');
       workspace.append('g').attr('class', 'drawings');
       if (debug) {

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -500,7 +500,7 @@ const GuitarBoard: React.FC = () => {
       .attr('stroke', frameStrokeColor)
       .attr('stroke-width', 2)
       .attr('stroke-dasharray', '8 4')
-      .style('pointer-events', 'visibleStroke');
+      .style('cursor', 'move');
 
     applyTransform(group, transform);
     group.call(makeDraggable);
@@ -1733,7 +1733,7 @@ const GuitarBoard: React.FC = () => {
         .attr('stroke', frameStrokeColor)
         .attr('stroke-width', 2)
         .attr('stroke-dasharray', '8 4')
-        .style('pointer-events', 'visibleStroke');
+        .style('cursor', 'move');
       frameSel.current = group;
       frameStart.current = { x, y };
       event.currentTarget.setPointerCapture(event.pointerId);

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -133,6 +133,7 @@ const GuitarBoard: React.FC = () => {
   const codeFontSize = app?.codeFontSize ?? 14;
   const drawingMode = app?.drawingMode ?? false;
   const frameMode = app?.frameMode ?? false;
+  const setFrameMode = app?.setFrameMode ?? (() => {});
   const brushWidth = app?.brushWidth ?? 'auto';
   const brushColor = app?.brushColor ?? defaultLineColor;
   const pushHistory = app?.pushHistory ?? (() => {});
@@ -1844,6 +1845,7 @@ const GuitarBoard: React.FC = () => {
       }
       frameSel.current = null;
       frameStart.current = null;
+      setFrameMode(false);
       event.currentTarget.releasePointerCapture(event.pointerId);
       return;
     }

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -70,6 +70,7 @@ const audioPadding = 10;
 const youtubeRegex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]+)/;
 
 const frameStrokeColor = '#4a90e2';
+const frameFillOpacity = 0.12;
 
 function extractVideoId(url: string): string | null {
   const match = url.match(youtubeRegex);
@@ -121,12 +122,15 @@ const getElementType = (node: Element | null): string | undefined => {
 const GuitarBoard: React.FC = () => {
   const app = useContext(AppContext);
   const stickyColor = app?.stickyColor ?? '#fef68a';
+  const frameColor = app?.frameColor ?? '#ffffff';
   const stickyAlign = app?.stickyAlign ?? 'center';
   const debug = app?.debug ?? false;
   const addBoard = app?.addBoard ?? (() => {});
   const setBoards = app?.setBoards ?? (() => {});
   const setBoardSelected = app?.setBoardSelected ?? (() => {});
   const setStickySelected = app?.setStickySelected ?? (() => {});
+  const setFrameSelected = app?.setFrameSelected ?? (() => {});
+  const setFrameColor = app?.setFrameColor ?? (() => {});
   const setCodeSelected = app?.setCodeSelected ?? (() => {});
   const codeLanguage = app?.codeLanguage ?? 'typescript';
   const codeTheme = app?.codeTheme ?? 'github-dark';
@@ -470,18 +474,19 @@ const GuitarBoard: React.FC = () => {
     return group;
   };
 
-  const createFrameGroup = useCallback((opts: { id?: string; width: number; height: number; transform: TransformValues; autoSelect?: boolean }) => {
+  const createFrameGroup = useCallback((opts: { id?: string; width: number; height: number; transform: TransformValues; color?: string; autoSelect?: boolean }) => {
     const svg = d3.select(svgRef.current);
     const layer = svg.select<SVGGElement>('.frames');
     const transform = { ...opts.transform };
     const group = layer.append('g')
       .attr('class', 'frame-element')
-      .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues }>({
+      .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues; color: string }>({
         id: opts.id ?? generateId(),
         type: 'frame',
         width: opts.width,
         height: opts.height,
         transform,
+        color: opts.color ?? frameColor,
       });
 
     group.append('rect')
@@ -490,7 +495,8 @@ const GuitarBoard: React.FC = () => {
       .attr('y', 0)
       .attr('width', opts.width)
       .attr('height', opts.height)
-      .attr('fill', 'transparent')
+      .attr('fill', opts.color ?? frameColor)
+      .attr('fill-opacity', frameFillOpacity)
       .attr('stroke', frameStrokeColor)
       .attr('stroke-width', 2)
       .attr('stroke-dasharray', '8 4')
@@ -509,7 +515,7 @@ const GuitarBoard: React.FC = () => {
     }
 
     return group;
-  }, [debug]);
+  }, [debug, frameColor]);
 
 
   const addSticky = useCallback((text: string, pos: { x: number, y: number }, opts: { fontSize?: number | null; color?: string; align?: 'left' | 'center' | 'right' } = {}) => {
@@ -1040,14 +1046,18 @@ const GuitarBoard: React.FC = () => {
       const width = info.data.width ?? 0;
       const height = info.data.height ?? 0;
       const baseTransform: TransformValues = info.data.transform ?? { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 };
+      const color = info.data.color ?? '#ffffff';
       const frame = createFrameGroup({
         id: info.data.id,
         width,
         height,
         transform: { ...baseTransform, translateX: pos.x, translateY: pos.y },
+        color,
       });
       const d = frame.datum() as any;
       d.id = info.data.id;
+      d.color = color;
+      frame.select('rect.frame-rect').attr('fill', color).attr('fill-opacity', frameFillOpacity);
     } else if (info.type === 'line') {
       const g = addLine(
         { x: info.data.x1, y: info.data.y1 },
@@ -1520,6 +1530,7 @@ const GuitarBoard: React.FC = () => {
   useEffect(() => {
     setStickySelected(false);
     setCodeSelected(false);
+    setFrameSelected(false);
     const handler = (e: Event) => {
       const node = (e as CustomEvent).detail as Node | null;
       if (!node) {
@@ -1527,10 +1538,19 @@ const GuitarBoard: React.FC = () => {
         setCodeSelected(false);
         setCroppableSelected(false);
         setSelectedBounds(null);
+        setFrameSelected(false);
       } else {
         const sel = d3.select(node);
-        setStickySelected(sel.classed('sticky-note'));
-        setCodeSelected(sel.classed('code-block'));
+        const isSticky = sel.classed('sticky-note');
+        const isCode = sel.classed('code-block');
+        const isFrame = sel.classed('frame-element');
+        setStickySelected(isSticky);
+        setCodeSelected(isCode);
+        setFrameSelected(isFrame);
+        if (isFrame) {
+          const data = sel.datum() as any;
+          setFrameColor((data && data.color) ? data.color : '#ffffff');
+        }
         setCroppableSelected(sel.classed('croppable'));
         const bbox = (node as SVGGraphicsElement).getBBox();
         const data: any = sel.datum() || {};
@@ -1542,7 +1562,7 @@ const GuitarBoard: React.FC = () => {
     };
     window.addEventListener('stickyselectionchange', handler);
     return () => window.removeEventListener('stickyselectionchange', handler);
-  }, [setStickySelected, setCodeSelected]);
+  }, [setStickySelected, setCodeSelected, setFrameSelected, setFrameColor]);
 
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
@@ -1694,12 +1714,13 @@ const GuitarBoard: React.FC = () => {
       const layer = svg.select<SVGGElement>('.frames');
       const group = layer.append('g')
         .attr('class', 'frame-element')
-        .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues }>({
+        .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues; color: string }>({
           id: generateId(),
           type: 'frame',
           width: 0,
           height: 0,
           transform: { translateX: x, translateY: y, scaleX: 1, scaleY: 1, rotate: 0 },
+          color: frameColor,
         });
       group.append('rect')
         .attr('class', 'frame-rect')
@@ -1707,7 +1728,8 @@ const GuitarBoard: React.FC = () => {
         .attr('y', 0)
         .attr('width', 0)
         .attr('height', 0)
-        .attr('fill', 'transparent')
+        .attr('fill', frameColor)
+        .attr('fill-opacity', frameFillOpacity)
         .attr('stroke', frameStrokeColor)
         .attr('stroke-width', 2)
         .attr('stroke-dasharray', '8 4')

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -7,6 +7,7 @@ import { chords, scales } from '../repertoire';
 import { noteColors, defaultLineColor } from '../theme';
 import { Button, Slider, Drawer, Box, Typography, IconButton, Checkbox, FormControlLabel, Table, TableHead, TableRow, TableCell, TableBody } from '@mui/material';
 import { AppContext } from '../Store';
+import type { FrameLineStyle } from '../Store';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { exportBoardPng } from '../exportPng';
 
@@ -71,6 +72,17 @@ const youtubeRegex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu
 
 const frameStrokeColor = '#4a90e2';
 const frameFillOpacity = 0.12;
+const frameStrokeStyles: Record<FrameLineStyle, { dash: string | null; linecap: 'butt' | 'round' }> = {
+  solid: { dash: null, linecap: 'butt' },
+  dashed: { dash: '8 4', linecap: 'butt' },
+  dotted: { dash: '2 4', linecap: 'round' },
+};
+const applyFrameStrokeStyle = (rect: d3.Selection<SVGRectElement, any, any, any>, style: FrameLineStyle) => {
+  const config = frameStrokeStyles[style] ?? frameStrokeStyles.solid;
+  rect
+    .attr('stroke-dasharray', config.dash ?? null)
+    .attr('stroke-linecap', config.linecap);
+};
 const interactiveElementSelector = '.pasted-image, .embedded-video, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board, .frame-element';
 
 function extractVideoId(url: string): string | null {
@@ -124,6 +136,7 @@ const GuitarBoard: React.FC = () => {
   const app = useContext(AppContext);
   const stickyColor = app?.stickyColor ?? '#fef68a';
   const frameColor = app?.frameColor ?? '#ffffff';
+  const frameLineStyle = app?.frameLineStyle ?? 'solid';
   const stickyAlign = app?.stickyAlign ?? 'center';
   const debug = app?.debug ?? false;
   const addBoard = app?.addBoard ?? (() => {});
@@ -132,6 +145,7 @@ const GuitarBoard: React.FC = () => {
   const setStickySelected = app?.setStickySelected ?? (() => {});
   const setFrameSelected = app?.setFrameSelected ?? (() => {});
   const setFrameColor = app?.setFrameColor ?? (() => {});
+  const setFrameLineStyle = app?.setFrameLineStyle ?? (() => {});
   const setCodeSelected = app?.setCodeSelected ?? (() => {});
   const codeLanguage = app?.codeLanguage ?? 'typescript';
   const codeTheme = app?.codeTheme ?? 'github-dark';
@@ -585,22 +599,24 @@ const GuitarBoard: React.FC = () => {
     event.stopPropagation();
   }, [finishRedirectedPointer]);
 
-  const createFrameGroup = useCallback((opts: { id?: string; width: number; height: number; transform: TransformValues; color?: string; autoSelect?: boolean }) => {
+  const createFrameGroup = useCallback((opts: { id?: string; width: number; height: number; transform: TransformValues; color?: string; lineStyle?: FrameLineStyle; autoSelect?: boolean }) => {
     const svg = d3.select(svgRef.current);
     const layer = svg.select<SVGGElement>('.frames');
     const transform = { ...opts.transform };
+    const lineStyle = opts.lineStyle ?? frameLineStyle;
     const group = layer.append('g')
       .attr('class', 'frame-element')
-      .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues; color: string }>({
+      .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues; color: string; lineStyle: FrameLineStyle }>({
         id: opts.id ?? generateId(),
         type: 'frame',
         width: opts.width,
         height: opts.height,
         transform,
         color: opts.color ?? frameColor,
+        lineStyle,
       });
 
-    group.append('rect')
+    const rect = group.append('rect')
       .attr('class', 'frame-rect')
       .attr('x', 0)
       .attr('y', 0)
@@ -610,12 +626,13 @@ const GuitarBoard: React.FC = () => {
       .attr('fill-opacity', frameFillOpacity)
       .attr('stroke', frameStrokeColor)
       .attr('stroke-width', 2)
-      .attr('stroke-dasharray', '8 4')
       .style('cursor', 'move')
       .on('pointerdown.frame-block', handleFramePointerDown)
       .on('pointermove.frame-block', handleFramePointerMove)
       .on('pointerup.frame-block', handleFramePointerUp)
       .on('pointercancel.frame-block', handleFramePointerCancel);
+
+    applyFrameStrokeStyle(rect, lineStyle);
 
     applyTransform(group, transform);
     group.call(makeDraggable);
@@ -633,6 +650,7 @@ const GuitarBoard: React.FC = () => {
   }, [
     debug,
     frameColor,
+    frameLineStyle,
     handleFramePointerCancel,
     handleFramePointerDown,
     handleFramePointerMove,
@@ -1169,17 +1187,22 @@ const GuitarBoard: React.FC = () => {
       const height = info.data.height ?? 0;
       const baseTransform: TransformValues = info.data.transform ?? { translateX: 0, translateY: 0, scaleX: 1, scaleY: 1, rotate: 0 };
       const color = info.data.color ?? '#ffffff';
+      const lineStyle: FrameLineStyle = info.data.lineStyle ?? 'solid';
       const frame = createFrameGroup({
         id: info.data.id,
         width,
         height,
         transform: { ...baseTransform, translateX: pos.x, translateY: pos.y },
         color,
+        lineStyle,
       });
       const d = frame.datum() as any;
       d.id = info.data.id;
       d.color = color;
-      frame.select('rect.frame-rect').attr('fill', color).attr('fill-opacity', frameFillOpacity);
+      d.lineStyle = lineStyle;
+      const rect = frame.select<SVGRectElement>('rect.frame-rect');
+      rect.attr('fill', color).attr('fill-opacity', frameFillOpacity);
+      applyFrameStrokeStyle(rect, lineStyle);
     } else if (info.type === 'line') {
       const g = addLine(
         { x: info.data.x1, y: info.data.y1 },
@@ -1672,6 +1695,7 @@ const GuitarBoard: React.FC = () => {
         if (isFrame) {
           const data = sel.datum() as any;
           setFrameColor((data && data.color) ? data.color : '#ffffff');
+          setFrameLineStyle((data && data.lineStyle) ? data.lineStyle : 'solid');
         }
         setCroppableSelected(sel.classed('croppable'));
         const bbox = (node as SVGGraphicsElement).getBBox();
@@ -1684,7 +1708,7 @@ const GuitarBoard: React.FC = () => {
     };
     window.addEventListener('stickyselectionchange', handler);
     return () => window.removeEventListener('stickyselectionchange', handler);
-  }, [setStickySelected, setCodeSelected, setFrameSelected, setFrameColor]);
+  }, [setStickySelected, setCodeSelected, setFrameSelected, setFrameColor, setFrameLineStyle]);
 
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
@@ -1836,15 +1860,16 @@ const GuitarBoard: React.FC = () => {
       const layer = svg.select<SVGGElement>('.frames');
       const group = layer.append('g')
         .attr('class', 'frame-element')
-        .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues; color: string }>({
+        .datum<{ id: string; type: 'frame'; width: number; height: number; transform: TransformValues; color: string; lineStyle: FrameLineStyle }>({
           id: generateId(),
           type: 'frame',
           width: 0,
           height: 0,
           transform: { translateX: x, translateY: y, scaleX: 1, scaleY: 1, rotate: 0 },
           color: frameColor,
+          lineStyle: frameLineStyle,
         });
-      group.append('rect')
+      const rect = group.append('rect')
         .attr('class', 'frame-rect')
         .attr('x', 0)
         .attr('y', 0)
@@ -1854,12 +1879,12 @@ const GuitarBoard: React.FC = () => {
         .attr('fill-opacity', frameFillOpacity)
         .attr('stroke', frameStrokeColor)
         .attr('stroke-width', 2)
-        .attr('stroke-dasharray', '8 4')
         .style('cursor', 'move')
         .on('pointerdown.frame-block', handleFramePointerDown)
         .on('pointermove.frame-block', handleFramePointerMove)
         .on('pointerup.frame-block', handleFramePointerUp)
         .on('pointercancel.frame-block', handleFramePointerCancel);
+      applyFrameStrokeStyle(rect, frameLineStyle);
       frameSel.current = group;
       frameStart.current = { x, y };
       event.currentTarget.setPointerCapture(event.pointerId);

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -2007,12 +2007,12 @@ const GuitarBoard: React.FC = () => {
     let workspace = svg.select<SVGGElement>('.workspace');
     if (workspace.empty()) {
       workspace = svg.append('g').attr('class', 'workspace');
+      workspace.append('g').attr('class', 'frames');
       workspace.append('g').attr('class', 'pasted-images');
       workspace.append('g').attr('class', 'embedded-videos');
       workspace.append('g').attr('class', 'embedded-audios');
       workspace.append('g').attr('class', 'sticky-notes');
       workspace.append('g').attr('class', 'code-blocks');
-      workspace.append('g').attr('class', 'frames');
       workspace.append('g').attr('class', 'lines');
       workspace.append('g').attr('class', 'drawings');
       if (debug) {
@@ -2027,6 +2027,10 @@ const GuitarBoard: React.FC = () => {
           .style('pointer-events', 'none')
           .text('+');
       }
+    }
+    const framesLayer = workspace.select<SVGGElement>('.frames');
+    if (!framesLayer.empty()) {
+      framesLayer.lower();
     }
     workspaceRef.current = workspace.node();
     setSvgRoot(svgRef.current, workspaceRef.current);

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -400,7 +400,14 @@ interface HiddenElementState {
 
 const DECORATION_SELECTOR = '.resize-handle, .rotate-handle, .connect-handle, .selection-outline, .component-debug-cross, .crop-controls';
 
-function getTightBoundingBox(node: SVGGraphicsElement): DOMRect | null {
+interface BoundingBox {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+function getTightBoundingBox(node: SVGGraphicsElement): BoundingBox | null {
     const element = d3.select(node);
     const hidden: HiddenElementState[] = [];
     element.selectAll<SVGGraphicsElement, unknown>(DECORATION_SELECTOR).each(function () {
@@ -413,7 +420,41 @@ function getTightBoundingBox(node: SVGGraphicsElement): DOMRect | null {
         child.style.display = 'none';
     });
     try {
-        return node.getBBox();
+        const bbox = node.getBBox();
+        const matrix = node.getScreenCTM() || node.getCTM();
+        if (!matrix) {
+            return {
+                x: bbox.x,
+                y: bbox.y,
+                width: bbox.width,
+                height: bbox.height,
+            };
+        }
+
+        const transformPoint = (x: number, y: number) => ({
+            x: matrix.a * x + matrix.c * y + matrix.e,
+            y: matrix.b * x + matrix.d * y + matrix.f,
+        });
+
+        const topLeft = transformPoint(bbox.x, bbox.y);
+        const topRight = transformPoint(bbox.x + bbox.width, bbox.y);
+        const bottomLeft = transformPoint(bbox.x, bbox.y + bbox.height);
+        const bottomRight = transformPoint(bbox.x + bbox.width, bbox.y + bbox.height);
+
+        const xs = [topLeft.x, topRight.x, bottomLeft.x, bottomRight.x];
+        const ys = [topLeft.y, topRight.y, bottomLeft.y, bottomRight.y];
+
+        const minX = Math.min(...xs);
+        const maxX = Math.max(...xs);
+        const minY = Math.min(...ys);
+        const maxY = Math.max(...ys);
+
+        return {
+            x: minX,
+            y: minY,
+            width: maxX - minX,
+            height: maxY - minY,
+        };
     } catch {
         return null;
     } finally {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -399,6 +399,16 @@ interface HiddenElementState {
 }
 
 const DECORATION_SELECTOR = '.resize-handle, .rotate-handle, .connect-handle, .selection-outline, .component-debug-cross, .crop-controls';
+const frameStrokePatterns: Record<'solid' | 'dashed' | 'dotted', { dash: string | null; linecap: 'butt' | 'round' }> = {
+    solid: { dash: null, linecap: 'butt' },
+    dashed: { dash: '8 4', linecap: 'butt' },
+    dotted: { dash: '2 4', linecap: 'round' },
+};
+
+function applyFrameStrokeAttributes(rect: Selection<SVGRectElement, any, any, any>, style: 'solid' | 'dashed' | 'dotted') {
+    const config = frameStrokePatterns[style] ?? frameStrokePatterns.solid;
+    rect.attr('stroke-dasharray', config.dash ?? null).attr('stroke-linecap', config.linecap);
+}
 
 interface BoundingBox {
     x: number;
@@ -673,6 +683,15 @@ export function updateSelectedFrameColor(color: string) {
         selectedElement.select<SVGRectElement>('rect.frame-rect').attr('fill', color);
         const data = selectedElement.datum() as any;
         data.color = color;
+    }
+}
+
+export function updateSelectedFrameLineStyle(style: 'solid' | 'dashed' | 'dotted') {
+    if (selectedElement && selectedElement.classed('frame-element')) {
+        const rect = selectedElement.select<SVGRectElement>('rect.frame-rect');
+        applyFrameStrokeAttributes(rect, style);
+        const data = selectedElement.datum() as any;
+        data.lineStyle = style;
     }
 }
 

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -392,6 +392,42 @@ interface FrameAttachment {
     lineBaseTransform?: TransformValues;
 }
 
+interface HiddenElementState {
+    node: SVGGraphicsElement;
+    displayAttr: string | null;
+    styleDisplay: string;
+}
+
+const DECORATION_SELECTOR = '.resize-handle, .rotate-handle, .connect-handle, .selection-outline, .component-debug-cross, .crop-controls';
+
+function getTightBoundingBox(node: SVGGraphicsElement): DOMRect | null {
+    const element = d3.select(node);
+    const hidden: HiddenElementState[] = [];
+    element.selectAll<SVGGraphicsElement, unknown>(DECORATION_SELECTOR).each(function () {
+        const child = this as SVGGraphicsElement;
+        hidden.push({
+            node: child,
+            displayAttr: child.getAttribute('display'),
+            styleDisplay: child.style.display,
+        });
+        child.style.display = 'none';
+    });
+    try {
+        return node.getBBox();
+    } catch {
+        return null;
+    } finally {
+        hidden.forEach(({ node: child, displayAttr, styleDisplay }) => {
+            if (displayAttr !== null) {
+                child.setAttribute('display', displayAttr);
+            } else {
+                child.removeAttribute('display');
+            }
+            child.style.display = styleDisplay;
+        });
+    }
+}
+
 export function makeDraggable(selection: Selection<any, any, any, any>) {
     interface DragDatum {
         dragOffsetX: number;
@@ -424,59 +460,63 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
                 let attachments: FrameAttachment[] | null = null;
                 if (element.classed('frame-element') && workspaceRoot) {
                     const frameNode = element.node() as SVGGraphicsElement;
-                    const frameBox = frameNode.getBBox();
-                    const workspace = d3.select(workspaceRoot);
-                    const selector = '.pasted-image, .embedded-video, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board, .frame-element';
-                    const collected: FrameAttachment[] = [];
-                    const attachedIds: Set<string> = new Set();
-                    workspace.selectAll<SVGGElement, any>(selector).each(function (ld: any) {
-                        if (this === frameNode) return;
-                        const el = d3.select(this);
-                        const box = (this as SVGGraphicsElement).getBBox();
-                        if (
-                            box.x >= frameBox.x &&
-                            box.y >= frameBox.y &&
-                            box.x + box.width <= frameBox.x + frameBox.width &&
-                            box.y + box.height <= frameBox.y + frameBox.height
-                        ) {
-                            if (ld?.type === 'line') {
-                                const base: TransformValues = ld?.transform ? { ...ld.transform } : { ...defaultTransform() };
-                                collected.push({
-                                    selection: el,
-                                    kind: 'line',
-                                    line: {
-                                        x1: (ld?.x1 ?? 0) + base.translateX,
-                                        y1: (ld?.y1 ?? 0) + base.translateY,
-                                        x2: (ld?.x2 ?? 0) + base.translateX,
-                                        y2: (ld?.y2 ?? 0) + base.translateY,
-                                    },
-                                    elementId: ld?.id,
-                                    lineBaseTransform: base,
-                                });
-                            } else {
-                                const base: TransformValues = ld?.transform ? { ...ld.transform } : { ...defaultTransform() };
-                                const attachment: FrameAttachment = {
-                                    selection: el,
-                                    kind: 'transform',
-                                    transform: base,
-                                    elementId: ld?.id,
-                                };
-                                collected.push(attachment);
-                                if (attachment.elementId) attachedIds.add(attachment.elementId);
+                    const frameBox = getTightBoundingBox(frameNode);
+                    if (frameBox) {
+                        const workspace = d3.select(workspaceRoot);
+                        const selector = '.pasted-image, .embedded-video, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board, .frame-element';
+                        const collected: FrameAttachment[] = [];
+                        const attachedIds: Set<string> = new Set();
+                        const epsilon = 0.5;
+                        workspace.selectAll<SVGGElement, any>(selector).each(function (ld: any) {
+                            if (this === frameNode) return;
+                            const el = d3.select(this);
+                            const box = getTightBoundingBox(this as SVGGraphicsElement);
+                            if (!box) return;
+                            if (
+                                box.x >= frameBox.x - epsilon &&
+                                box.y >= frameBox.y - epsilon &&
+                                box.x + box.width <= frameBox.x + frameBox.width + epsilon &&
+                                box.y + box.height <= frameBox.y + frameBox.height + epsilon
+                            ) {
+                                if (ld?.type === 'line') {
+                                    const base: TransformValues = ld?.transform ? { ...ld.transform } : { ...defaultTransform() };
+                                    collected.push({
+                                        selection: el,
+                                        kind: 'line',
+                                        line: {
+                                            x1: (ld?.x1 ?? 0) + base.translateX,
+                                            y1: (ld?.y1 ?? 0) + base.translateY,
+                                            x2: (ld?.x2 ?? 0) + base.translateX,
+                                            y2: (ld?.y2 ?? 0) + base.translateY,
+                                        },
+                                        elementId: ld?.id,
+                                        lineBaseTransform: base,
+                                    });
+                                } else {
+                                    const base: TransformValues = ld?.transform ? { ...ld.transform } : { ...defaultTransform() };
+                                    const attachment: FrameAttachment = {
+                                        selection: el,
+                                        kind: 'transform',
+                                        transform: base,
+                                        elementId: ld?.id,
+                                    };
+                                    collected.push(attachment);
+                                    if (attachment.elementId) attachedIds.add(attachment.elementId);
+                                }
                             }
-                        }
-                    });
-                    collected.forEach(att => {
-                        if (att.kind === 'line') {
-                            const data = att.selection.datum() as any;
-                            const startFollow = data?.startConn && attachedIds.has(data.startConn.elementId);
-                            const endFollow = data?.endConn && attachedIds.has(data.endConn.elementId);
-                            if (startFollow && endFollow) {
-                                att.followConnections = true;
+                        });
+                        collected.forEach(att => {
+                            if (att.kind === 'line') {
+                                const data = att.selection.datum() as any;
+                                const startFollow = data?.startConn && attachedIds.has(data.startConn.elementId);
+                                const endFollow = data?.endConn && attachedIds.has(data.endConn.elementId);
+                                if (startFollow && endFollow) {
+                                    att.followConnections = true;
+                                }
                             }
-                        }
-                    });
-                    attachments = collected.length ? collected : null;
+                        });
+                        attachments = collected.length ? collected : null;
+                    }
                 }
 
                 Object.assign(data, {

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -668,6 +668,14 @@ export function updateSelectedColor(color: string) {
     }
 }
 
+export function updateSelectedFrameColor(color: string) {
+    if (selectedElement && selectedElement.classed('frame-element')) {
+        selectedElement.select<SVGRectElement>('rect.frame-rect').attr('fill', color);
+        const data = selectedElement.datum() as any;
+        data.color = color;
+    }
+}
+
 export function updateSelectedAlignment(align: 'left' | 'center' | 'right') {
     if (selectedElement && selectedElement.classed('sticky-note')) {
         selectedElement.select<HTMLElement>('foreignObject > .sticky-text')
@@ -1202,6 +1210,7 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
         d3.select(window).on('click.makeResizable', (event: MouseEvent) => {
             const controls = document.getElementById('board-controls');
             const colorSelect = document.getElementById('sticky-color-select');
+            const frameColorSelect = document.getElementById('frame-color-select');
             const alignControls = document.getElementById('sticky-align-controls');
             const target = event.target as Node;
             const isSvg = target instanceof SVGElement;
@@ -1211,6 +1220,7 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
                 !selectedElement.node()?.contains(target) &&
                 !(controls && controls.contains(target)) &&
                 !(colorSelect && colorSelect.contains(target)) &&
+                !(frameColorSelect && frameColorSelect.contains(target)) &&
                 !(alignControls && alignControls.contains(target))
             ) {
                 clearSelection();

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -382,6 +382,16 @@ export function applyTransform(element: Selection<any, any, any, any>, transform
     }
 }
 
+interface FrameAttachment {
+    selection: Selection<any, any, any, any>;
+    kind: 'transform' | 'line';
+    transform?: TransformValues;
+    line?: { x1: number; y1: number; x2: number; y2: number };
+    elementId?: string;
+    followConnections?: boolean;
+    lineBaseTransform?: TransformValues;
+}
+
 export function makeDraggable(selection: Selection<any, any, any, any>) {
     interface DragDatum {
         dragOffsetX: number;
@@ -390,6 +400,7 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
         startX: number;
         startY: number;
         moved?: boolean;
+        attachments?: FrameAttachment[] | null;
     };
 
     selection.call(
@@ -410,7 +421,73 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
                 const dragOffsetY = startY - transform.translateY;
 
                 debugLog('drag start', transform.translateX, transform.translateY);
-                Object.assign(data, { dragOffsetX, dragOffsetY, transform, startX: transform.translateX, startY: transform.translateY, moved: false });
+                let attachments: FrameAttachment[] | null = null;
+                if (element.classed('frame-element') && workspaceRoot) {
+                    const frameNode = element.node() as SVGGraphicsElement;
+                    const frameBox = frameNode.getBBox();
+                    const workspace = d3.select(workspaceRoot);
+                    const selector = '.pasted-image, .embedded-video, .embedded-audio, .sticky-note, .code-block, .line-element, .drawing, .guitar-board, .frame-element';
+                    const collected: FrameAttachment[] = [];
+                    const attachedIds: Set<string> = new Set();
+                    workspace.selectAll<SVGGElement, any>(selector).each(function (ld: any) {
+                        if (this === frameNode) return;
+                        const el = d3.select(this);
+                        const box = (this as SVGGraphicsElement).getBBox();
+                        if (
+                            box.x >= frameBox.x &&
+                            box.y >= frameBox.y &&
+                            box.x + box.width <= frameBox.x + frameBox.width &&
+                            box.y + box.height <= frameBox.y + frameBox.height
+                        ) {
+                            if (ld?.type === 'line') {
+                                const base: TransformValues = ld?.transform ? { ...ld.transform } : { ...defaultTransform() };
+                                collected.push({
+                                    selection: el,
+                                    kind: 'line',
+                                    line: {
+                                        x1: (ld?.x1 ?? 0) + base.translateX,
+                                        y1: (ld?.y1 ?? 0) + base.translateY,
+                                        x2: (ld?.x2 ?? 0) + base.translateX,
+                                        y2: (ld?.y2 ?? 0) + base.translateY,
+                                    },
+                                    elementId: ld?.id,
+                                    lineBaseTransform: base,
+                                });
+                            } else {
+                                const base: TransformValues = ld?.transform ? { ...ld.transform } : { ...defaultTransform() };
+                                const attachment: FrameAttachment = {
+                                    selection: el,
+                                    kind: 'transform',
+                                    transform: base,
+                                    elementId: ld?.id,
+                                };
+                                collected.push(attachment);
+                                if (attachment.elementId) attachedIds.add(attachment.elementId);
+                            }
+                        }
+                    });
+                    collected.forEach(att => {
+                        if (att.kind === 'line') {
+                            const data = att.selection.datum() as any;
+                            const startFollow = data?.startConn && attachedIds.has(data.startConn.elementId);
+                            const endFollow = data?.endConn && attachedIds.has(data.endConn.elementId);
+                            if (startFollow && endFollow) {
+                                att.followConnections = true;
+                            }
+                        }
+                    });
+                    attachments = collected.length ? collected : null;
+                }
+
+                Object.assign(data, {
+                    dragOffsetX,
+                    dragOffsetY,
+                    transform,
+                    startX: transform.translateX,
+                    startY: transform.translateY,
+                    moved: false,
+                    attachments,
+                });
                 element.datum(data);
                 setGridVisible(event.ctrlKey);
             })
@@ -446,6 +523,43 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
                 }
 
                 applyTransform(element, newTransform);
+                const dx = newX - startX;
+                const dy = newY - startY;
+                if (data.attachments) {
+                    data.attachments.forEach(att => {
+                        if (att.kind === 'transform' && att.transform) {
+                            const base = att.transform;
+                            const nextTransform: TransformValues = {
+                                ...base,
+                                translateX: base.translateX + dx,
+                                translateY: base.translateY + dy,
+                            };
+                            applyTransform(att.selection, nextTransform);
+                        } else if (att.kind === 'line' && att.line && !att.followConnections) {
+                            const lineData = att.selection.datum() as any;
+                            const base = att.lineBaseTransform ?? defaultTransform();
+                            const newX1Abs = att.line.x1 + dx;
+                            const newY1Abs = att.line.y1 + dy;
+                            const newX2Abs = att.line.x2 + dx;
+                            const newY2Abs = att.line.y2 + dy;
+                            lineData.x1 = newX1Abs - base.translateX;
+                            lineData.y1 = newY1Abs - base.translateY;
+                            lineData.x2 = newX2Abs - base.translateX;
+                            lineData.y2 = newY2Abs - base.translateY;
+                            lineData.transform = { ...base };
+                            att.selection.select('path').attr('d', linePath(lineData));
+                            att.selection.select('circle.start').attr('cx', lineData.x1).attr('cy', lineData.y1);
+                            att.selection.select('circle.end').attr('cx', lineData.x2).attr('cy', lineData.y2);
+                            const path = att.selection.select<SVGPathElement>('path').node();
+                            if (path) {
+                                const mid = path.getPointAtLength(path.getTotalLength() / 2);
+                                att.selection.select<SVGTextElement>('text.line-label')
+                                    .attr('x', mid.x)
+                                    .attr('y', mid.y);
+                            }
+                        }
+                    });
+                }
                 setGridVisible(!!ctrl);
                 debugLog('drag', newTransform.translateX, newTransform.translateY);
             })
@@ -655,7 +769,7 @@ export function applyLineAppearance(element: Selection<SVGGElement, any, any, an
 
 
 export interface ElementCopy {
-    type: 'image' | 'video' | 'audio' | 'sticky' | 'board' | 'drawing' | 'code' | 'line' | 'meta';
+    type: 'image' | 'video' | 'audio' | 'sticky' | 'board' | 'drawing' | 'code' | 'line' | 'frame' | 'meta';
     data: any;
 }
 
@@ -670,6 +784,7 @@ export function getSelectedElementData(): ElementCopy | null {
     else if (selectedElement.classed('guitar-board')) type = 'board';
     else if (selectedElement.classed('drawing')) type = 'drawing';
     else if (selectedElement.classed('line-element')) type = 'line';
+    else if (selectedElement.classed('frame-element')) type = 'frame';
     if (!type) return null;
     const data = { ...(selectedElement.datum() as any) };
     if (type === 'board') {


### PR DESCRIPTION
## Summary
- add a frame tool button and keyboard shortcut to toggle drawing frames
- implement frame drawing in the workspace, including grouped dragging and history/serialization support
- update help text and README to document the frame shortcut and behaviour

## Testing
- ⚠️ `npm install` *(fails: registry access to shiki is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea317fdeac832e98678fb3fef3655e