### PR TITLE
Fix resizable overlay scaling

### DIFF
--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -366,6 +366,55 @@ function buildTransform(transform: TransformValues, size: { width: number; heigh
     return `translate(${translateX}, ${translateY}) rotate(${rotate}, ${cx}, ${cy}) scale(${scaleX}, ${scaleY})`;
 }
 
+const intrinsicResizeClasses = new Set([
+    'sticky-note',
+    'code-block',
+    'pasted-image',
+    'embedded-video',
+    'embedded-audio',
+    'frame-element',
+]);
+
+function supportsIntrinsicResize(element: Selection<any, any, any, any>): boolean {
+    return Array.from(intrinsicResizeClasses).some(cls => element.classed(cls));
+}
+
+function applyElementSize(element: Selection<any, any, any, any>, width: number, height: number) {
+    const data = element.datum() as any || {};
+    data.width = width;
+    data.height = height;
+    element.datum(data);
+
+    if (element.classed('sticky-note')) {
+        element.select('rect').attr('width', width).attr('height', height);
+        element.select('foreignObject').attr('width', width).attr('height', height);
+    } else if (element.classed('code-block')) {
+        element.select('rect').attr('width', width).attr('height', height);
+        element.select('foreignObject').attr('width', width).attr('height', height);
+    } else if (element.classed('pasted-image')) {
+        element.select('image').attr('width', width).attr('height', height);
+    } else if (element.classed('embedded-video') || element.classed('embedded-audio')) {
+        element.select('rect').attr('width', width).attr('height', height);
+        const fo = element.select<SVGForeignObjectElement>('foreignObject');
+        if (!fo.empty()) {
+            const padX = parseFloat(fo.attr('x') ?? '0');
+            const padY = parseFloat(fo.attr('y') ?? '0');
+            const innerWidth = Math.max(0, width - padX * 2);
+            const innerHeight = Math.max(0, height - padY * 2);
+            fo.attr('width', innerWidth).attr('height', innerHeight);
+        }
+    } else if (element.classed('frame-element')) {
+        element.select<SVGRectElement>('rect.frame-rect')
+            .attr('width', width)
+            .attr('height', height);
+    }
+
+    const overlay = element.select('.crop-controls');
+    if (!overlay.empty() && overlay.style('display') !== 'none') {
+        updateCropOverlay(element);
+    }
+}
+
 export function applyTransform(element: Selection<any, any, any, any>, transform: TransformValues) {
     const data: any = element.datum() || {};
     data.transform = transform;
@@ -385,6 +434,8 @@ export function applyTransform(element: Selection<any, any, any, any>, transform
     const connectRadius = 4;
 
     element.selectAll<SVGRectElement, any>('.selection-outline')
+        .attr('width', width)
+        .attr('height', height)
         .attr('stroke-width', 1 / combinedScale)
         .attr('vector-effect', 'non-scaling-stroke');
 
@@ -1016,15 +1067,15 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                     .datum({ startX, startY, transform, width, height, origWidth: width, origHeight: height });
             })
             .on('drag', function (event: MouseEvent) {
-                const data = d3.select<any, any>(this).datum();
-                const { transform } = data;
+                const dragData = d3.select<any, any>(this).datum();
+                const { transform, width, height } = dragData;
 
                 const [mx, my] = toWorkspaceCoords(event);
-                const dx = mx - data.startX;
-                const dy = my - data.startY;
+                const dx = mx - dragData.startX;
+                const dy = my - dragData.startY;
 
-                let newScaleX = Math.max(0.1, (data.width * transform.scaleX + dx) / data.width);
-                let newScaleY = Math.max(0.1, (data.height * transform.scaleY + dy) / data.height);
+                let newScaleX = Math.max(0.1, (width * transform.scaleX + dx) / Math.max(width, 1e-6));
+                let newScaleY = Math.max(0.1, (height * transform.scaleY + dy) / Math.max(height, 1e-6));
 
                 const source = (event as any).sourceEvent as MouseEvent | undefined;
                 const shift = source?.shiftKey;
@@ -1036,69 +1087,35 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                 }
 
                 if (ctrl) {
-                    const snapWidth = Math.round((data.width * newScaleX) / 10) * 10;
-                    const snapHeight = Math.round((data.height * newScaleY) / 10) * 10;
-                    newScaleX = snapWidth / data.width;
-                    newScaleY = snapHeight / data.height;
+                    const snapWidth = Math.round((width * newScaleX) / 10) * 10;
+                    const snapHeight = Math.round((height * newScaleY) / 10) * 10;
+                    newScaleX = snapWidth / Math.max(width, 1e-6);
+                    newScaleY = snapHeight / Math.max(height, 1e-6);
                 }
 
-                const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+                const elementData = element.datum() as any;
 
-                if (element.classed('sticky-note') || element.classed('code-block')) {
-                    const stickyData = element.datum() as any;
-                    const width = data.origWidth * newScaleX;
-                    const height = data.origHeight * newScaleY;
-                    stickyData.width = width;
-                    stickyData.height = height;
-                    element.select('rect').attr('width', width).attr('height', height);
-                    element.select('foreignObject').attr('width', width).attr('height', height);
-                    element.select('.selection-outline').attr('width', width).attr('height', height);
-                    element.select('.rotate-handle')
-                        .attr('x', width + handleSize / zoomScale)
-                        .attr('y', -handleSize / zoomScale)
-                        .attr('font-size', handleSize / zoomScale);
+                if (supportsIntrinsicResize(element)) {
+                    const actualWidth = width * newScaleX;
+                    const actualHeight = height * newScaleY;
+                    applyElementSize(element, actualWidth, actualHeight);
                     const newTransform: TransformValues = { ...transform, scaleX: 1, scaleY: 1 };
+                    elementData.transform = newTransform;
                     applyTransform(element, newTransform);
-                    d3.select(this)
-                        .attr('x', width + handleSize / zoomScale)
-                        .attr('y', height + handleSize / zoomScale)
-                        .attr('font-size', handleSize / zoomScale);
-                    updateDebugCross(element);
-                    debugLog('resize drag', width, height);
+                    debugLog('resize drag', actualWidth, actualHeight);
                 } else {
                     const newTransform: TransformValues = { ...transform, scaleX: newScaleX, scaleY: newScaleY };
+                    elementData.transform = newTransform;
                     applyTransform(element, newTransform);
-
-                    const scaledWidth = data.width * newScaleX;
-                    const scaledHeight = data.height * newScaleY;
-
-                    const safeScaleX = newScaleX === 0 ? (newScaleX >= 0 ? 1e-6 : -1e-6) : newScaleX;
-                    const safeScaleY = newScaleY === 0 ? (newScaleY >= 0 ? 1e-6 : -1e-6) : newScaleY;
-                    const combinedScale = Math.max(Math.max(Math.abs(newScaleX), Math.abs(newScaleY)) * zoomScale, 1e-6);
-                    const offsetScaleX = safeScaleX * zoomScale;
-                    const offsetScaleY = safeScaleY * zoomScale;
-
-                    d3.select(this)
-                        .attr('x', data.width + handleSize / offsetScaleX)
-                        .attr('y', data.height + handleSize / offsetScaleY)
-                        .attr('font-size', handleSize / combinedScale);
-
-                    const rotateHandle = element.select('.rotate-handle');
-                    if (!rotateHandle.empty()) {
-                        rotateHandle
-                            .attr('x', data.width + handleSize / offsetScaleX)
-                            .attr('y', -handleSize / offsetScaleY)
-                            .attr('font-size', handleSize / combinedScale);
-                    }
-
-                    updateDebugCross(element);
                     debugLog('resize drag', newScaleX, newScaleY);
                 }
+
+                updateDebugCross(element);
                 setGridVisible(!!ctrl);
             })
             .on('end', function () {
                 window.dispatchEvent(new CustomEvent('element-resize-end', { detail: element.node() }));
-                if ((element.classed('sticky-note') || element.classed('code-block')) && typeof options.onResizeEnd === 'function') {
+                if (supportsIntrinsicResize(element) && typeof options.onResizeEnd === 'function') {
                     options.onResizeEnd(element);
                 }
                 updateDebugCross(element);

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -174,6 +174,10 @@ export const defaultTransform = (): TransformValues => ({
     rotate: 0,
 });
 
+const HANDLE_ICON_SIZE = 16;
+const CONNECT_HANDLE_RADIUS = 4;
+const SELECTION_STROKE_WIDTH = 1;
+
 function transformPoint(x: number, y: number, t: TransformValues, size: { width: number; height: number }) {
     const cx = (size.width * t.scaleX) / 2;
     const cy = (size.height * t.scaleY) / 2;
@@ -183,6 +187,79 @@ function transformPoint(x: number, y: number, t: TransformValues, size: { width:
     const rx = Math.cos(rad) * (px - cx) - Math.sin(rad) * (py - cy) + cx;
     const ry = Math.sin(rad) * (px - cx) + Math.cos(rad) * (py - cy) + cy;
     return { x: rx + t.translateX, y: ry + t.translateY };
+}
+
+interface DecorationLayoutOptions {
+    width?: number;
+    height?: number;
+    transform?: TransformValues;
+}
+
+function computeDecorationMetrics(transform: TransformValues) {
+    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+    const scaleX = transform.scaleX ?? 1;
+    const scaleY = transform.scaleY ?? 1;
+    const safeScaleX = scaleX === 0 ? (scaleX >= 0 ? 1e-6 : -1e-6) : scaleX;
+    const safeScaleY = scaleY === 0 ? (scaleY >= 0 ? 1e-6 : -1e-6) : scaleY;
+    const dominantScale = Math.max(Math.abs(safeScaleX), Math.abs(safeScaleY), 1e-6);
+    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
+    return {
+        zoomScale,
+        combinedScale,
+        offsetScaleX: safeScaleX * zoomScale,
+        offsetScaleY: safeScaleY * zoomScale,
+    };
+}
+
+function updateSelectionDecorations(
+    element: Selection<any, any, any, any>,
+    options: DecorationLayoutOptions = {},
+) {
+    const data: any = element.datum() || {};
+    const node = element.node() as SVGGraphicsElement;
+    const bbox = node.getBBox();
+    const width = options.width ?? data.width ?? bbox.width;
+    const height = options.height ?? data.height ?? bbox.height;
+    const transform: TransformValues = options.transform ?? data.transform ?? defaultTransform();
+    const metrics = computeDecorationMetrics(transform);
+
+    element.selectAll<SVGRectElement, any>('.selection-outline')
+        .attr('width', width)
+        .attr('height', height)
+        .attr('stroke-width', SELECTION_STROKE_WIDTH)
+        .attr('vector-effect', 'non-scaling-stroke');
+
+    const handleFontSize = HANDLE_ICON_SIZE / metrics.combinedScale;
+    const resizeHandles = element.selectAll<SVGTextElement, any>('.resize-handle');
+    resizeHandles
+        .attr('x', width + HANDLE_ICON_SIZE / metrics.offsetScaleX)
+        .attr('y', height + HANDLE_ICON_SIZE / metrics.offsetScaleY)
+        .attr('font-size', handleFontSize)
+        .style('font-size', `${handleFontSize}px`)
+        .attr('vector-effect', 'non-scaling-stroke');
+
+    const rotateHandles = element.selectAll<SVGTextElement, any>('.rotate-handle');
+    rotateHandles
+        .attr('x', width + HANDLE_ICON_SIZE / metrics.offsetScaleX)
+        .attr('y', -HANDLE_ICON_SIZE / metrics.offsetScaleY)
+        .attr('font-size', handleFontSize)
+        .style('font-size', `${handleFontSize}px`)
+        .attr('vector-effect', 'non-scaling-stroke');
+
+    const connectRadius = CONNECT_HANDLE_RADIUS / metrics.combinedScale;
+    element.selectAll<SVGCircleElement, any>('.connect-handle').each(function () {
+        const h = d3.select(this);
+        const pos = h.attr('data-pos');
+        let x = 0;
+        let y = 0;
+        if (pos === 'n') { x = width / 2; y = 0; }
+        if (pos === 'e') { x = width; y = height / 2; }
+        if (pos === 's') { x = width / 2; y = height; }
+        if (pos === 'w') { x = 0; y = height / 2; }
+        h.attr('cx', x).attr('cy', y).attr('r', connectRadius);
+        const abs = transformPoint(x, y, transform, { width, height });
+        h.attr('data-abs-x', abs.x).attr('data-abs-y', abs.y);
+    });
 }
 
 export function linePath(d: {
@@ -470,49 +547,7 @@ export function applyTransform(element: Selection<any, any, any, any>, transform
     const height = data.height ?? (element.node() as SVGGraphicsElement).getBBox().height;
     element.attr('transform', buildTransform(transform, { width, height }));
 
-    const { scaleX, scaleY } = transform;
-    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
-    const dominantScale = Math.max(Math.abs(scaleX), Math.abs(scaleY), 1e-6);
-    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
-    const safeScaleX = scaleX === 0 ? (scaleX >= 0 ? 1e-6 : -1e-6) : scaleX;
-    const safeScaleY = scaleY === 0 ? (scaleY >= 0 ? 1e-6 : -1e-6) : scaleY;
-    const offsetScaleX = safeScaleX * zoomScale;
-    const offsetScaleY = safeScaleY * zoomScale;
-    const handleSize = 16;
-    const connectRadius = 4;
-
-    element.selectAll<SVGRectElement, any>('.selection-outline')
-        .attr('width', width)
-        .attr('height', height)
-        .attr('stroke-width', 1 / combinedScale)
-        .attr('vector-effect', 'non-scaling-stroke');
-
-    element.selectAll<SVGTextElement, any>('.resize-handle')
-        .attr('x', width + handleSize / offsetScaleX)
-        .attr('y', height + handleSize / offsetScaleY)
-        .attr('font-size', handleSize / combinedScale)
-        .attr('vector-effect', 'non-scaling-stroke');
-
-    element.selectAll<SVGTextElement, any>('.rotate-handle')
-        .attr('x', width + handleSize / offsetScaleX)
-        .attr('y', -handleSize / offsetScaleY)
-        .attr('font-size', handleSize / combinedScale)
-        .attr('vector-effect', 'non-scaling-stroke');
-
-    const handles = element.selectAll<SVGCircleElement, any>('.connect-handle');
-    handles.each(function () {
-        const h = d3.select(this);
-        const pos = h.attr('data-pos');
-        let x = 0, y = 0;
-        if (pos === 'n') { x = width / 2; y = 0; }
-        if (pos === 'e') { x = width; y = height / 2; }
-        if (pos === 's') { x = width / 2; y = height; }
-        if (pos === 'w') { x = 0; y = height / 2; }
-        h.attr('cx', x).attr('cy', y);
-        h.attr('r', connectRadius / combinedScale);
-        const p = transformPoint(x, y, transform, { width, height });
-        h.attr('data-abs-x', p.x).attr('data-abs-y', p.y);
-    });
+    updateSelectionDecorations(element, { width, height, transform });
     updateConnectedLines(element);
     if (selectedElement && element.node() === selectedElement.node()) {
         dispatchSelectionChange();
@@ -1054,7 +1089,6 @@ interface ResizeOptions {
 
 function addResizeHandle(element: Selection<any, any, any, any>, options: ResizeOptions = {}) {
     const { lockAspectRatio = true } = options;
-    const handleSize = 16;
 
     if (!element.select('.resize-handle').empty()) return;
 
@@ -1064,23 +1098,15 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
     const height = data.height ?? bbox.height;
     const transform: TransformValues = data.transform ?? defaultTransform();
     data.transform = transform;
-    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
-    const dominantScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
-    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
-    const safeScaleX = transform.scaleX === 0 ? (transform.scaleX >= 0 ? 1e-6 : -1e-6) : transform.scaleX;
-    const safeScaleY = transform.scaleY === 0 ? (transform.scaleY >= 0 ? 1e-6 : -1e-6) : transform.scaleY;
-    const offsetScaleX = safeScaleX * zoomScale;
-    const offsetScaleY = safeScaleY * zoomScale;
 
     const handle = element.append('text')
         .attr('class', 'resize-handle')
-        .attr('x', width + handleSize / offsetScaleX)
-        .attr('y', height + handleSize / offsetScaleY)
         .text('\u2921')
-        .attr('font-size', handleSize / combinedScale)
         .style('cursor', 'nwse-resize')
         .style('user-select', 'none')
         .attr('vector-effect', 'non-scaling-stroke');
+
+    updateSelectionDecorations(element, { width, height, transform });
 
     if (!element.select('.component-debug-cross').empty()) {
         updateDebugCross(element);
@@ -1174,8 +1200,6 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
 }
 
 function addRotateHandle(element: Selection<any, any, any, any>) {
-    const handleSize = 16;
-
     if (!element.select('.rotate-handle').empty()) return;
 
     const data: any = element.datum();
@@ -1184,19 +1208,9 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
     const height = data.height ?? bbox.height;
     const transform: TransformValues = data.transform ?? defaultTransform();
     data.transform = transform;
-    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
-    const dominantScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
-    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
-    const safeScaleX = transform.scaleX === 0 ? (transform.scaleX >= 0 ? 1e-6 : -1e-6) : transform.scaleX;
-    const safeScaleY = transform.scaleY === 0 ? (transform.scaleY >= 0 ? 1e-6 : -1e-6) : transform.scaleY;
-    const offsetScaleX = safeScaleX * zoomScale;
-    const offsetScaleY = safeScaleY * zoomScale;
     element.append('text')
         .attr('class', 'rotate-handle')
-        .attr('x', width + handleSize / offsetScaleX)
-        .attr('y', -handleSize / offsetScaleY)
         .text('\u21bb')
-        .attr('font-size', handleSize / combinedScale)
         .style('cursor', 'grab')
         .style('user-select', 'none')
         .attr('vector-effect', 'non-scaling-stroke')
@@ -1250,6 +1264,8 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
                     debugLog('rotate', newTransform.rotate);
                 })
         );
+
+    updateSelectionDecorations(element, { width, height, transform });
 }
 
 export function ensureConnectHandles(element: Selection<any, any, any, any>) {
@@ -1259,11 +1275,6 @@ export function ensureConnectHandles(element: Selection<any, any, any, any>) {
     const width = data.width ?? bbox.width;
     const height = data.height ?? bbox.height;
     const transform = data.transform ?? defaultTransform();
-    const { scaleX, scaleY } = transform;
-    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
-    const dominantScale = Math.max(Math.abs(scaleX), Math.abs(scaleY), 1e-6);
-    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
-    const r = 4 / combinedScale;
     const points = [
         { p: 'n', x: width / 2, y: 0 },
         { p: 'e', x: width, y: height / 2 },
@@ -1273,15 +1284,10 @@ export function ensureConnectHandles(element: Selection<any, any, any, any>) {
     points.forEach(pt => {
         const h = element.append('circle')
             .attr('class', `connect-handle connect-handle-${pt.p}`)
-            .attr('cx', pt.x)
-            .attr('cy', pt.y)
-            .attr('r', r)
             .attr('data-pos', pt.p)
             .attr('data-parent', data.id)
             .style('pointer-events', 'all')
             .style('fill', '#7fbbf7');
-        const abs = transformPoint(pt.x, pt.y, transform, { width, height });
-        h.attr('data-abs-x', abs.x).attr('data-abs-y', abs.y);
         h.call(
             d3.drag<SVGCircleElement, unknown>()
                 .on('start', function (event) {
@@ -1298,6 +1304,8 @@ export function ensureConnectHandles(element: Selection<any, any, any, any>) {
                 })
         );
     });
+
+    updateSelectionDecorations(element, { width, height, transform });
 }
 
 export function removeConnectHandles(element: Selection<any, any, any, any>) {
@@ -1312,10 +1320,6 @@ function addOutline(element: Selection<any, any, any, any>) {
     const width = data.width ?? bbox.width;
     const height = data.height ?? bbox.height;
     const transform = data.transform ?? defaultTransform();
-    const { scaleX, scaleY } = transform;
-    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
-    const dominantScale = Math.max(Math.abs(scaleX), Math.abs(scaleY), 1e-6);
-    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
 
     element.append('rect')
         .attr('class', 'selection-outline')
@@ -1325,9 +1329,10 @@ function addOutline(element: Selection<any, any, any, any>) {
         .attr('height', height)
         .attr('fill', 'none')
         .attr('stroke', '#7fbbf7')
-        .attr('stroke-width', 1 / combinedScale)
         .style('pointer-events', 'none')
         .attr('vector-effect', 'non-scaling-stroke');
+
+    updateSelectionDecorations(element, { width, height, transform });
 }
 
 function clearSelection() {
@@ -1428,10 +1433,7 @@ function updateCropOverlay(element: Selection<any, any, any, any>) {
     const rect = overlay.select<SVGRectElement>('.crop-rect');
     const data = (element.datum() as any) || {};
     const transform: TransformValues = data.transform ?? defaultTransform();
-    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
-    const elementScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
-    const combinedScale = Math.max(elementScale * zoomScale, 1e-6);
-    const handleSize = 16;
+    const metrics = computeDecorationMetrics(transform);
 
     const imgWidth = parseFloat(image.attr('width') ?? '0');
     const imgHeight = parseFloat(image.attr('height') ?? '0');
@@ -1482,11 +1484,12 @@ function updateCropOverlay(element: Selection<any, any, any, any>) {
         .attr('height', height);
 
     rect
-        .attr('stroke-width', 1 / combinedScale)
+        .attr('stroke-width', SELECTION_STROKE_WIDTH)
         .attr('vector-effect', 'non-scaling-stroke');
 
     overlay.selectAll<SVGTextElement, any>('.crop-handle')
-        .attr('font-size', handleSize / combinedScale);
+        .attr('font-size', HANDLE_ICON_SIZE / metrics.combinedScale)
+        .style('font-size', `${HANDLE_ICON_SIZE / metrics.combinedScale}px`);
 }
 
 function startCrop(element: Selection<any, any, any, any>) {
@@ -1589,16 +1592,13 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
 
             const elementData = (element.datum() as any) || {};
             const transform: TransformValues = elementData.transform ?? defaultTransform();
-            const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
-            const elementScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
-            const combinedScale = Math.max(elementScale * zoomScale, 1e-6);
-            const handleSize = 16;
+            const metrics = computeDecorationMetrics(transform);
 
             overlay.append('rect')
                 .attr('class', 'crop-rect')
                 .attr('fill', 'none')
                 .attr('stroke', '#7fbbf7')
-                .attr('stroke-width', 1 / combinedScale)
+                .attr('stroke-width', SELECTION_STROKE_WIDTH)
                 .attr('vector-effect', 'non-scaling-stroke');
 
             const handleClasses = ['n', 'e', 's', 'w'];
@@ -1607,7 +1607,8 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
                 overlay.append('text')
                     .attr('class', `crop-handle crop-handle-${dir}`)
                     .text(char)
-                    .attr('font-size', handleSize / combinedScale)
+                    .attr('font-size', HANDLE_ICON_SIZE / metrics.combinedScale)
+                    .style('font-size', `${HANDLE_ICON_SIZE / metrics.combinedScale}px`)
                     .attr('text-anchor', 'middle')
                     .attr('dominant-baseline', 'middle')
                     .style('user-select', 'none')

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -381,6 +381,9 @@ function supportsIntrinsicResize(element: Selection<any, any, any, any>): boolea
 
 function applyElementSize(element: Selection<any, any, any, any>, width: number, height: number) {
     const data = element.datum() as any || {};
+    const prevWidth = data.width ?? (element.node() as SVGGraphicsElement).getBBox().width;
+    const prevHeight = data.height ?? (element.node() as SVGGraphicsElement).getBBox().height;
+
     data.width = width;
     data.height = height;
     element.datum(data);
@@ -393,6 +396,51 @@ function applyElementSize(element: Selection<any, any, any, any>, width: number,
         element.select('foreignObject').attr('width', width).attr('height', height);
     } else if (element.classed('pasted-image')) {
         element.select('image').attr('width', width).attr('height', height);
+
+        const clipRect = element.select<SVGRectElement>('.clip-rect');
+        if (!clipRect.empty()) {
+            const scaleX = prevWidth ? width / Math.max(prevWidth, 1e-6) : 1;
+            const scaleY = prevHeight ? height / Math.max(prevHeight, 1e-6) : 1;
+            if (data.crop) {
+                data.crop = {
+                    x: (data.crop.x ?? 0) * scaleX,
+                    y: (data.crop.y ?? 0) * scaleY,
+                    width: (data.crop.width ?? 0) * scaleX,
+                    height: (data.crop.height ?? 0) * scaleY,
+                } as CropValues;
+                clipRect
+                    .attr('x', data.crop.x)
+                    .attr('y', data.crop.y)
+                    .attr('width', data.crop.width)
+                    .attr('height', data.crop.height);
+            } else {
+                clipRect
+                    .attr('x', 0)
+                    .attr('y', 0)
+                    .attr('width', width)
+                    .attr('height', height);
+            }
+
+            const overlay = element.select('.crop-controls');
+            if (!overlay.empty()) {
+                const overlayRect = overlay.select<SVGRectElement>('.crop-rect');
+                if (!overlayRect.empty()) {
+                    if (data.crop) {
+                        overlayRect
+                            .attr('x', data.crop.x)
+                            .attr('y', data.crop.y)
+                            .attr('width', data.crop.width)
+                            .attr('height', data.crop.height);
+                    } else {
+                        overlayRect
+                            .attr('x', 0)
+                            .attr('y', 0)
+                            .attr('width', width)
+                            .attr('height', height);
+                    }
+                }
+            }
+        }
     } else if (element.classed('embedded-video') || element.classed('embedded-audio')) {
         element.select('rect').attr('width', width).attr('height', height);
         const fo = element.select<SVGForeignObjectElement>('foreignObject');

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -363,6 +363,30 @@ export function applyTransform(element: Selection<any, any, any, any>, transform
     const width = data.width ?? (element.node() as SVGGraphicsElement).getBBox().width;
     const height = data.height ?? (element.node() as SVGGraphicsElement).getBBox().height;
     element.attr('transform', buildTransform(transform, { width, height }));
+
+    const { scaleX, scaleY } = transform;
+    const dominantScale = Math.max(Math.abs(scaleX), Math.abs(scaleY), 1e-6);
+    const safeScaleX = scaleX === 0 ? (scaleX >= 0 ? 1e-6 : -1e-6) : scaleX;
+    const safeScaleY = scaleY === 0 ? (scaleY >= 0 ? 1e-6 : -1e-6) : scaleY;
+    const handleSize = 16;
+    const connectRadius = 4;
+
+    element.selectAll<SVGRectElement, any>('.selection-outline')
+        .attr('stroke-width', 1 / dominantScale)
+        .attr('vector-effect', 'non-scaling-stroke');
+
+    element.selectAll<SVGTextElement, any>('.resize-handle')
+        .attr('x', width + handleSize / safeScaleX)
+        .attr('y', height + handleSize / safeScaleY)
+        .attr('font-size', handleSize / dominantScale)
+        .attr('vector-effect', 'non-scaling-stroke');
+
+    element.selectAll<SVGTextElement, any>('.rotate-handle')
+        .attr('x', width + handleSize / safeScaleX)
+        .attr('y', -handleSize / safeScaleY)
+        .attr('font-size', handleSize / dominantScale)
+        .attr('vector-effect', 'non-scaling-stroke');
+
     const handles = element.selectAll<SVGCircleElement, any>('.connect-handle');
     handles.each(function () {
         const h = d3.select(this);
@@ -373,6 +397,7 @@ export function applyTransform(element: Selection<any, any, any, any>, transform
         if (pos === 's') { x = width / 2; y = height; }
         if (pos === 'w') { x = 0; y = height / 2; }
         h.attr('cx', x).attr('cy', y);
+        h.attr('r', connectRadius / dominantScale);
         const p = transformPoint(x, y, transform, { width, height });
         h.attr('data-abs-x', p.x).attr('data-abs-y', p.y);
     });
@@ -936,7 +961,7 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
         .attr('font-size', handleSize / Math.max(transform.scaleX, transform.scaleY))
         .style('cursor', 'nwse-resize')
         .style('user-select', 'none')
-        .style('vector-effect', 'non-scaling-stroke');
+        .attr('vector-effect', 'non-scaling-stroke');
 
     if (!element.select('.component-debug-cross').empty()) {
         updateDebugCross(element);
@@ -1073,7 +1098,7 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
         .attr('font-size', handleSize / Math.max(transform.scaleX, transform.scaleY))
         .style('cursor', 'grab')
         .style('user-select', 'none')
-        .style('vector-effect', 'non-scaling-stroke')
+        .attr('vector-effect', 'non-scaling-stroke')
         .call(
             d3.drag<SVGTextElement, unknown>()
                 .on('start', function (event: MouseEvent) {
@@ -1191,10 +1216,10 @@ function addOutline(element: Selection<any, any, any, any>) {
         .attr('width', width)
         .attr('height', height)
         .attr('fill', 'none')
-    .attr('stroke', '#7fbbf7')
+        .attr('stroke', '#7fbbf7')
         .attr('stroke-width', 1 / Math.max(scaleX, scaleY))
         .style('pointer-events', 'none')
-        .style('vector-effect', 'non-scaling-stroke');
+        .attr('vector-effect', 'non-scaling-stroke');
 }
 
 function clearSelection() {
@@ -1457,7 +1482,7 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
                     .attr('text-anchor', 'middle')
                     .attr('dominant-baseline', 'middle')
                     .style('user-select', 'none')
-                    .style('vector-effect', 'non-scaling-stroke');
+                    .attr('vector-effect', 'non-scaling-stroke');
             }
 
             overlay.append('rect').attr('class', 'crop-shade-top');

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -22,6 +22,15 @@ export function setDebugMode(enabled: boolean) {
 
 export function setZoomTransform(transform: d3.ZoomTransform) {
     zoomTransform = transform;
+    if (selectedElement) {
+        const data = (selectedElement.datum() as any) || {};
+        const currentTransform: TransformValues = data.transform ?? defaultTransform();
+        applyTransform(selectedElement, currentTransform);
+        const overlay = selectedElement.select('.crop-controls');
+        if (!overlay.empty() && overlay.style('display') !== 'none') {
+            updateCropOverlay(selectedElement);
+        }
+    }
 }
 
 export function setSvgRoot(svg: SVGSVGElement | null, workspace?: SVGGElement | null) {
@@ -365,26 +374,30 @@ export function applyTransform(element: Selection<any, any, any, any>, transform
     element.attr('transform', buildTransform(transform, { width, height }));
 
     const { scaleX, scaleY } = transform;
+    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
     const dominantScale = Math.max(Math.abs(scaleX), Math.abs(scaleY), 1e-6);
+    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
     const safeScaleX = scaleX === 0 ? (scaleX >= 0 ? 1e-6 : -1e-6) : scaleX;
     const safeScaleY = scaleY === 0 ? (scaleY >= 0 ? 1e-6 : -1e-6) : scaleY;
+    const offsetScaleX = safeScaleX * zoomScale;
+    const offsetScaleY = safeScaleY * zoomScale;
     const handleSize = 16;
     const connectRadius = 4;
 
     element.selectAll<SVGRectElement, any>('.selection-outline')
-        .attr('stroke-width', 1 / dominantScale)
+        .attr('stroke-width', 1 / combinedScale)
         .attr('vector-effect', 'non-scaling-stroke');
 
     element.selectAll<SVGTextElement, any>('.resize-handle')
-        .attr('x', width + handleSize / safeScaleX)
-        .attr('y', height + handleSize / safeScaleY)
-        .attr('font-size', handleSize / dominantScale)
+        .attr('x', width + handleSize / offsetScaleX)
+        .attr('y', height + handleSize / offsetScaleY)
+        .attr('font-size', handleSize / combinedScale)
         .attr('vector-effect', 'non-scaling-stroke');
 
     element.selectAll<SVGTextElement, any>('.rotate-handle')
-        .attr('x', width + handleSize / safeScaleX)
-        .attr('y', -handleSize / safeScaleY)
-        .attr('font-size', handleSize / dominantScale)
+        .attr('x', width + handleSize / offsetScaleX)
+        .attr('y', -handleSize / offsetScaleY)
+        .attr('font-size', handleSize / combinedScale)
         .attr('vector-effect', 'non-scaling-stroke');
 
     const handles = element.selectAll<SVGCircleElement, any>('.connect-handle');
@@ -397,7 +410,7 @@ export function applyTransform(element: Selection<any, any, any, any>, transform
         if (pos === 's') { x = width / 2; y = height; }
         if (pos === 'w') { x = 0; y = height / 2; }
         h.attr('cx', x).attr('cy', y);
-        h.attr('r', connectRadius / dominantScale);
+        h.attr('r', connectRadius / combinedScale);
         const p = transformPoint(x, y, transform, { width, height });
         h.attr('data-abs-x', p.x).attr('data-abs-y', p.y);
     });
@@ -952,13 +965,20 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
     const height = data.height ?? bbox.height;
     const transform: TransformValues = data.transform ?? defaultTransform();
     data.transform = transform;
+    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+    const dominantScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
+    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
+    const safeScaleX = transform.scaleX === 0 ? (transform.scaleX >= 0 ? 1e-6 : -1e-6) : transform.scaleX;
+    const safeScaleY = transform.scaleY === 0 ? (transform.scaleY >= 0 ? 1e-6 : -1e-6) : transform.scaleY;
+    const offsetScaleX = safeScaleX * zoomScale;
+    const offsetScaleY = safeScaleY * zoomScale;
 
     const handle = element.append('text')
         .attr('class', 'resize-handle')
-        .attr('x', width + handleSize / transform.scaleX)
-        .attr('y', height + handleSize / transform.scaleY)
+        .attr('x', width + handleSize / offsetScaleX)
+        .attr('y', height + handleSize / offsetScaleY)
         .text('\u2921')
-        .attr('font-size', handleSize / Math.max(transform.scaleX, transform.scaleY))
+        .attr('font-size', handleSize / combinedScale)
         .style('cursor', 'nwse-resize')
         .style('user-select', 'none')
         .attr('vector-effect', 'non-scaling-stroke');
@@ -1022,6 +1042,8 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                     newScaleY = snapHeight / data.height;
                 }
 
+                const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+
                 if (element.classed('sticky-note') || element.classed('code-block')) {
                     const stickyData = element.datum() as any;
                     const width = data.origWidth * newScaleX;
@@ -1032,14 +1054,15 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                     element.select('foreignObject').attr('width', width).attr('height', height);
                     element.select('.selection-outline').attr('width', width).attr('height', height);
                     element.select('.rotate-handle')
-                        .attr('x', width + handleSize)
-                        .attr('font-size', handleSize);
+                        .attr('x', width + handleSize / zoomScale)
+                        .attr('y', -handleSize / zoomScale)
+                        .attr('font-size', handleSize / zoomScale);
                     const newTransform: TransformValues = { ...transform, scaleX: 1, scaleY: 1 };
                     applyTransform(element, newTransform);
                     d3.select(this)
-                        .attr('x', width + handleSize)
-                        .attr('y', height + handleSize)
-                        .attr('font-size', handleSize);
+                        .attr('x', width + handleSize / zoomScale)
+                        .attr('y', height + handleSize / zoomScale)
+                        .attr('font-size', handleSize / zoomScale);
                     updateDebugCross(element);
                     debugLog('resize drag', width, height);
                 } else {
@@ -1049,17 +1072,23 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                     const scaledWidth = data.width * newScaleX;
                     const scaledHeight = data.height * newScaleY;
 
+                    const safeScaleX = newScaleX === 0 ? (newScaleX >= 0 ? 1e-6 : -1e-6) : newScaleX;
+                    const safeScaleY = newScaleY === 0 ? (newScaleY >= 0 ? 1e-6 : -1e-6) : newScaleY;
+                    const combinedScale = Math.max(Math.max(Math.abs(newScaleX), Math.abs(newScaleY)) * zoomScale, 1e-6);
+                    const offsetScaleX = safeScaleX * zoomScale;
+                    const offsetScaleY = safeScaleY * zoomScale;
+
                     d3.select(this)
-                        .attr('x', data.width + handleSize / newScaleX)
-                        .attr('y', data.height + handleSize / newScaleY)
-                        .attr('font-size', handleSize / Math.max(newScaleX, newScaleY));
+                        .attr('x', data.width + handleSize / offsetScaleX)
+                        .attr('y', data.height + handleSize / offsetScaleY)
+                        .attr('font-size', handleSize / combinedScale);
 
                     const rotateHandle = element.select('.rotate-handle');
                     if (!rotateHandle.empty()) {
                         rotateHandle
-                            .attr('x', data.width + handleSize / newScaleX)
-                            .attr('y', -handleSize / newScaleY)
-                            .attr('font-size', handleSize / Math.max(newScaleX, newScaleY));
+                            .attr('x', data.width + handleSize / offsetScaleX)
+                            .attr('y', -handleSize / offsetScaleY)
+                            .attr('font-size', handleSize / combinedScale);
                     }
 
                     updateDebugCross(element);
@@ -1090,12 +1119,19 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
     const height = data.height ?? bbox.height;
     const transform: TransformValues = data.transform ?? defaultTransform();
     data.transform = transform;
+    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+    const dominantScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
+    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
+    const safeScaleX = transform.scaleX === 0 ? (transform.scaleX >= 0 ? 1e-6 : -1e-6) : transform.scaleX;
+    const safeScaleY = transform.scaleY === 0 ? (transform.scaleY >= 0 ? 1e-6 : -1e-6) : transform.scaleY;
+    const offsetScaleX = safeScaleX * zoomScale;
+    const offsetScaleY = safeScaleY * zoomScale;
     element.append('text')
         .attr('class', 'rotate-handle')
-        .attr('x', width + handleSize / transform.scaleX)
-        .attr('y', -handleSize / transform.scaleY)
+        .attr('x', width + handleSize / offsetScaleX)
+        .attr('y', -handleSize / offsetScaleY)
         .text('\u21bb')
-        .attr('font-size', handleSize / Math.max(transform.scaleX, transform.scaleY))
+        .attr('font-size', handleSize / combinedScale)
         .style('cursor', 'grab')
         .style('user-select', 'none')
         .attr('vector-effect', 'non-scaling-stroke')
@@ -1159,7 +1195,10 @@ export function ensureConnectHandles(element: Selection<any, any, any, any>) {
     const height = data.height ?? bbox.height;
     const transform = data.transform ?? defaultTransform();
     const { scaleX, scaleY } = transform;
-    const r = 4 / Math.max(scaleX, scaleY);
+    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+    const dominantScale = Math.max(Math.abs(scaleX), Math.abs(scaleY), 1e-6);
+    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
+    const r = 4 / combinedScale;
     const points = [
         { p: 'n', x: width / 2, y: 0 },
         { p: 'e', x: width, y: height / 2 },
@@ -1207,7 +1246,11 @@ function addOutline(element: Selection<any, any, any, any>) {
     const bbox = (element.node() as SVGGraphicsElement).getBBox();
     const width = data.width ?? bbox.width;
     const height = data.height ?? bbox.height;
-    const { scaleX, scaleY } = (data.transform ?? defaultTransform());
+    const transform = data.transform ?? defaultTransform();
+    const { scaleX, scaleY } = transform;
+    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+    const dominantScale = Math.max(Math.abs(scaleX), Math.abs(scaleY), 1e-6);
+    const combinedScale = Math.max(dominantScale * zoomScale, 1e-6);
 
     element.append('rect')
         .attr('class', 'selection-outline')
@@ -1217,7 +1260,7 @@ function addOutline(element: Selection<any, any, any, any>) {
         .attr('height', height)
         .attr('fill', 'none')
         .attr('stroke', '#7fbbf7')
-        .attr('stroke-width', 1 / Math.max(scaleX, scaleY))
+        .attr('stroke-width', 1 / combinedScale)
         .style('pointer-events', 'none')
         .attr('vector-effect', 'non-scaling-stroke');
 }
@@ -1318,6 +1361,12 @@ function updateCropOverlay(element: Selection<any, any, any, any>) {
     const image = element.select('image');
     const overlay = element.select('.crop-controls');
     const rect = overlay.select<SVGRectElement>('.crop-rect');
+    const data = (element.datum() as any) || {};
+    const transform: TransformValues = data.transform ?? defaultTransform();
+    const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+    const elementScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
+    const combinedScale = Math.max(elementScale * zoomScale, 1e-6);
+    const handleSize = 16;
 
     const imgWidth = parseFloat(image.attr('width') ?? '0');
     const imgHeight = parseFloat(image.attr('height') ?? '0');
@@ -1366,6 +1415,13 @@ function updateCropOverlay(element: Selection<any, any, any, any>) {
         .attr('y', y)
         .attr('width', imgWidth - x - width)
         .attr('height', height);
+
+    rect
+        .attr('stroke-width', 1 / combinedScale)
+        .attr('vector-effect', 'non-scaling-stroke');
+
+    overlay.selectAll<SVGTextElement, any>('.crop-handle')
+        .attr('font-size', handleSize / combinedScale);
 }
 
 function startCrop(element: Selection<any, any, any, any>) {
@@ -1466,11 +1522,19 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
                 .attr('class', 'crop-controls')
                 .style('display', 'none');
 
+            const elementData = (element.datum() as any) || {};
+            const transform: TransformValues = elementData.transform ?? defaultTransform();
+            const zoomScale = Math.max(Math.abs(zoomTransform.k), 1e-6);
+            const elementScale = Math.max(Math.abs(transform.scaleX), Math.abs(transform.scaleY), 1e-6);
+            const combinedScale = Math.max(elementScale * zoomScale, 1e-6);
+            const handleSize = 16;
+
             overlay.append('rect')
                 .attr('class', 'crop-rect')
                 .attr('fill', 'none')
                 .attr('stroke', '#7fbbf7')
-                .attr('stroke-width', 1);
+                .attr('stroke-width', 1 / combinedScale)
+                .attr('vector-effect', 'non-scaling-stroke');
 
             const handleClasses = ['n', 'e', 's', 'w'];
             for (const dir of handleClasses) {
@@ -1478,7 +1542,7 @@ export function makeCroppable(selection: Selection<any, any, any, any>) {
                 overlay.append('text')
                     .attr('class', `crop-handle crop-handle-${dir}`)
                     .text(char)
-                    .attr('font-size', 16)
+                    .attr('font-size', handleSize / combinedScale)
                     .attr('text-anchor', 'middle')
                     .attr('dominant-baseline', 'middle')
                     .style('user-select', 'none')


### PR DESCRIPTION
## Summary
- keep resize, rotate, and connection handles from shrinking while elements are scaled
- maintain selection outline thickness by updating stroke width and using SVG vector-effect attributes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea8417bb5c832ea379bec61210d2f3