### PR TITLE
Improve zoom behavior and add reset shortcut

### DIFF
--- a/src/HelpDialog.tsx
+++ b/src/HelpDialog.tsx
@@ -17,6 +17,7 @@ const shortcuts: ShortcutSection[] = [
       { key: 'Ctrl+Z / Cmd+Z', action: 'Undo last change' },
       { key: 'Ctrl+Shift+Z / Cmd+Shift+Z', action: 'Redo last undone change' },
       { key: 'r', action: 'Reset element rotation' },
+      { key: '0', action: 'Reset board zoom to default level' },
       { key: '/ or ?', action: 'Open this help dialog' },
       { key: 'Ctrl+S', action: 'Export board as extra-high-resolution PNG image (save icon)' },
       { key: 'Ctrl+drag', action: 'Snap movement to grid' },

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1630,6 +1630,17 @@ const GuitarBoard: React.FC = () => {
     return () => window.removeEventListener('loadlyrics', handler as EventListener);
   }, [addCodeBlock, codeTheme, codeFontSize, getSpawnPosition, pushHistory]);
 
+  const resetZoom = useCallback(() => {
+    if (zoomBehaviorRef.current && svgRef.current) {
+      d3.select(svgRef.current)
+        .transition()
+        .call(zoomBehaviorRef.current.transform, d3.zoomIdentity);
+    }
+    zoomRef.current = d3.zoomIdentity;
+    setZoomValue(1);
+    setZoomTransform(d3.zoomIdentity);
+  }, []);
+
   useEffect(() => {
     const handle = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
@@ -2190,17 +2201,6 @@ const GuitarBoard: React.FC = () => {
       setZoomValue(initialZoom.current.k);
       initialZoom.current = null;
     }
-  }, []);
-
-  const resetZoom = useCallback(() => {
-    if (zoomBehaviorRef.current && svgRef.current) {
-      d3.select(svgRef.current)
-        .transition()
-        .call(zoomBehaviorRef.current.transform, d3.zoomIdentity);
-    }
-    zoomRef.current = d3.zoomIdentity;
-    setZoomValue(1);
-    setZoomTransform(d3.zoomIdentity);
   }, []);
 
   const updateLyricConnections = useCallback(() => {

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1650,17 +1650,24 @@ const GuitarBoard: React.FC = () => {
         window.dispatchEvent(new Event('createboard'));
         e.preventDefault();
         e.stopImmediatePropagation();
+      } else if (e.key === '0' && !e.ctrlKey && !e.metaKey) {
+        resetZoom();
+        e.preventDefault();
+        e.stopImmediatePropagation();
       }
     };
     window.addEventListener('keydown', handle, true);
     return () => window.removeEventListener('keydown', handle, true);
-  }, [croppableSelected, codeLanguage, codeTheme]);
+  }, [croppableSelected, codeLanguage, codeTheme, resetZoom]);
 
   useEffect(() => {
     if (zoomBehaviorRef.current && svgRef.current) {
       zoomBehaviorRef.current.filter(event => {
         if (event.type === 'dblclick') return false;
         const e = event as any;
+        if (event.type === 'wheel' || event.type === 'mousewheel') {
+          return true;
+        }
         if (e.ctrlKey) return false;
         if (drawingMode || frameMode) return false;
         const target = e.target as Element;
@@ -2157,6 +2164,9 @@ const GuitarBoard: React.FC = () => {
       .filter(event => {
         if (event.type === 'dblclick') return false;
         const e = event as any;
+        if (event.type === 'wheel' || event.type === 'mousewheel') {
+          return true;
+        }
         if (e.ctrlKey) return false;
         if (drawingMode) return false;
         const target = e.target as Element;
@@ -2180,6 +2190,17 @@ const GuitarBoard: React.FC = () => {
       setZoomValue(initialZoom.current.k);
       initialZoom.current = null;
     }
+  }, []);
+
+  const resetZoom = useCallback(() => {
+    if (zoomBehaviorRef.current && svgRef.current) {
+      d3.select(svgRef.current)
+        .transition()
+        .call(zoomBehaviorRef.current.transform, d3.zoomIdentity);
+    }
+    zoomRef.current = d3.zoomIdentity;
+    setZoomValue(1);
+    setZoomTransform(d3.zoomIdentity);
   }, []);
 
   const updateLyricConnections = useCallback(() => {
@@ -2283,12 +2304,7 @@ const GuitarBoard: React.FC = () => {
         ></svg>
         <Box sx={{ position: 'absolute', bottom: 8, left: 8, backgroundColor: 'rgba(255,255,255,0.7)', borderRadius: 1, display: 'flex', alignItems: 'center', px: 1 }}>
           <Typography variant="body2" sx={{ mr: 1 }}>{zoomValue.toFixed(2)}x</Typography>
-          <IconButton size="small" onClick={() => {
-            if (zoomBehaviorRef.current && svgRef.current) {
-              d3.select(svgRef.current).transition().call(zoomBehaviorRef.current.transform, d3.zoomIdentity);
-              setZoomValue(1);
-            }
-          }}>
+          <IconButton size="small" onClick={resetZoom}>
             <RestartAltIcon fontSize="small" />
           </IconButton>
           {debug && (

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -1195,8 +1195,9 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
                             .attr('font-size', handleSize / Math.max(newScaleX, newScaleY));
                     }
 
-                updateDebugCross(element);
-                setGridVisible(!!ctrl);
+                    updateDebugCross(element);
+                    setGridVisible(!!ctrl);
+                }
             })
             .on('end', function () {
                 window.dispatchEvent(new CustomEvent('element-resize-end', { detail: element.node() }));
@@ -1239,15 +1240,15 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
                     const data = element.datum() as any;
                     const transform: TransformValues = data.transform ?? defaultTransform();
                     data.transform = transform;
-                const bbox = (element.node() as SVGGraphicsElement).getBBox();
-                const width = data.width ?? bbox.width;
-                const height = data.height ?? bbox.height;
-                const centerX = transform.translateX + (width * transform.scaleX) / 2;
-                const centerY = transform.translateY + (height * transform.scaleY) / 2;
-                const [sx, sy] = toWorkspaceCoords(event);
-                const startAngle = Math.atan2(sy - centerY, sx - centerX);
-                const cumulative = transform.rotate * Math.PI / 180;
-                debugLog('rotate start', startAngle);
+                    const bbox = (element.node() as SVGGraphicsElement).getBBox();
+                    const width = data.width ?? bbox.width;
+                    const height = data.height ?? bbox.height;
+                    const centerX = transform.translateX + (width * transform.scaleX) / 2;
+                    const centerY = transform.translateY + (height * transform.scaleY) / 2;
+                    const [sx, sy] = toWorkspaceCoords(event);
+                    const startAngle = Math.atan2(sy - centerY, sx - centerX);
+                    const cumulative = transform.rotate * Math.PI / 180;
+                    debugLog('rotate start', startAngle);
 
                     d3.select(this).datum({ centerX, centerY, lastAngle: startAngle, cumulative, transform });
                 })


### PR DESCRIPTION
## Summary
- ensure wheel-based global zoom continues working even when the cursor is above workspace elements
- add a reusable zoom reset helper and bind it to the existing button and the new `0` shortcut
- document the reset shortcut in the help dialog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebaeb5c580832ea4f43198b6f4e105