### PR TITLE
Allow middle/right button panning and disable context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { Box, CssBaseline, ThemeProvider } from "@mui/material";
 
@@ -18,6 +19,16 @@ function App() {
   const getBasename = () => {
     return window.location.pathname;
   };
+
+  useEffect(() => {
+    const disableContextMenu = (event: MouseEvent) => {
+      event.preventDefault();
+    };
+    window.addEventListener('contextmenu', disableContextMenu);
+    return () => {
+      window.removeEventListener('contextmenu', disableContextMenu);
+    };
+  }, []);
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -366,7 +366,7 @@ const Menu: React.FC = () => {
         backdropFilter: 'blur(12px)',
       }}
     >
-      <Toolbar id="board-toolbar" sx={{ display: 'flex', gap: 1 }}>
+      <Toolbar id="board-toolbar" sx={{ display: 'flex', gap: 1, minHeight: 100, alignItems: 'center' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1, gap: 1 }}>
           <Tooltip title="Main menu">
             <IconButton
@@ -762,75 +762,70 @@ const Menu: React.FC = () => {
                   aria-label="Edge feather amount"
                 />
               </Box>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.75)' }}>
-                  Background color: {imageBackgroundColor ? imageBackgroundColor.toUpperCase() : 'Auto'}
-                </Typography>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Box
-                    sx={{
-                      width: 28,
-                      height: 18,
-                      borderRadius: '999px',
-                      border: '1px solid rgba(255,255,255,0.4)',
-                      backgroundColor: imageBackgroundColor ?? 'transparent',
-                      backgroundImage: imageBackgroundColor
-                        ? 'none'
-                        : 'linear-gradient(135deg, rgba(255,255,255,0.2) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, transparent 75%, transparent)',
-                      backgroundSize: '8px 8px',
-                    }}
-                  />
-                  <Tooltip title="Choose background color">
-                    <span>
-                      <IconButton
-                        color="inherit"
-                        onClick={(event) => {
-                          event.stopPropagation();
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                <Box
+                  sx={{
+                    width: 28,
+                    height: 18,
+                    borderRadius: '999px',
+                    border: '1px solid rgba(255,255,255,0.4)',
+                    backgroundColor: imageBackgroundColor ?? 'transparent',
+                    backgroundImage: imageBackgroundColor
+                      ? 'none'
+                      : 'linear-gradient(135deg, rgba(255,255,255,0.2) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, transparent 75%, transparent)',
+                    backgroundSize: '8px 8px',
+                  }}
+                />
+                <Tooltip title="Choose background color">
+                  <span>
+                    <IconButton
+                      color="inherit"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        colorInputRef.current?.click();
+                      }}
+                      disabled={imageProcessing !== null}
+                      sx={baseToolButtonSx}
+                      aria-label="Choose background color"
+                    >
+                      <PaletteIcon />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+                <Tooltip
+                  title={
+                    canUseEyeDropper
+                      ? 'Sample background color from the screen'
+                      : 'EyeDropper unavailable – opens the colour picker instead'
+                  }
+                >
+                  <span>
+                    <IconButton
+                      color="inherit"
+                      onClick={async (event) => {
+                        event.stopPropagation();
+                        if (!canUseEyeDropper || !window.EyeDropper) {
                           colorInputRef.current?.click();
-                        }}
-                        disabled={imageProcessing !== null}
-                        sx={baseToolButtonSx}
-                        aria-label="Choose background color"
-                      >
-                        <PaletteIcon />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                  <Tooltip
-                    title={
-                      canUseEyeDropper
-                        ? 'Sample background color from the screen'
-                        : 'EyeDropper unavailable – opens the colour picker instead'
-                    }
-                  >
-                    <span>
-                      <IconButton
-                        color="inherit"
-                        onClick={async (event) => {
-                          event.stopPropagation();
-                          if (!canUseEyeDropper || !window.EyeDropper) {
-                            colorInputRef.current?.click();
-                            return;
+                          return;
+                        }
+                        try {
+                          const dropper = new window.EyeDropper();
+                          const result = await dropper.open();
+                          applyBackgroundColor(result?.sRGBHex ?? null);
+                        } catch (err) {
+                          if ((err as DOMException)?.name !== 'AbortError') {
+                            console.error('Failed to sample color', err);
                           }
-                          try {
-                            const dropper = new window.EyeDropper();
-                            const result = await dropper.open();
-                            applyBackgroundColor(result?.sRGBHex ?? null);
-                          } catch (err) {
-                            if ((err as DOMException)?.name !== 'AbortError') {
-                              console.error('Failed to sample color', err);
-                            }
-                          }
-                        }}
-                        disabled={imageProcessing !== null}
-                        sx={baseToolButtonSx}
-                        aria-label="Sample background color"
-                      >
-                        <ColorizeIcon />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                </Box>
+                        }
+                      }}
+                      disabled={imageProcessing !== null}
+                      sx={baseToolButtonSx}
+                      aria-label="Sample background color"
+                    >
+                      <ColorizeIcon />
+                    </IconButton>
+                  </span>
+                </Tooltip>
               </Box>
               <Tooltip title="Reset to automatic strength and default feather">
                 <span>

--- a/src/components/GuitarBoard.tsx
+++ b/src/components/GuitarBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useContext, useCallback } from 'react';
 import * as d3 from 'd3';
-import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, applyLineAppearance, TransformValues, defaultBackgroundFeather, defaultBackgroundFeather } from '../d3-ext';
+import { debugTooltip, makeDraggable, makeResizable, makeCroppable, applyTransform, hideTooltip, adjustStickyFont, addDebugCross, setZoomTransform, setSvgRoot, getSelectedElementData, ElementCopy, generateId, highlightCode, linePath, ensureConnectHandles, removeConnectHandles, updateSelectedLineColor, updateSelectedStartConnectionStyle, updateSelectedEndConnectionStyle, applyLineAppearance, TransformValues, defaultBackgroundFeather } from '../d3-ext';
 
 import { noteString, stringNames, calculateNote, ScaleOrChordShape } from '../music-theory';
 import { chords, scales } from '../repertoire';
@@ -2252,15 +2252,25 @@ const GuitarBoard: React.FC = () => {
   useEffect(() => {
     const svg = d3.select(svgRef.current);
     const zoom = d3.zoom<SVGSVGElement, unknown>()
-      .filter(event => {
+      .filter((event: any) => {
         if (event.type === 'dblclick') return false;
-        const e = event as any;
         if (event.type === 'wheel' || event.type === 'mousewheel') {
           return true;
         }
-        if (e.ctrlKey) return false;
+        if (event.ctrlKey) return false;
         if (drawingMode) return false;
-        const target = e.target as Element;
+
+        const mouseEvent = event as MouseEvent & { target: EventTarget | null };
+        if (mouseEvent) {
+          if (mouseEvent.button === 1 || mouseEvent.button === 2) {
+            return true;
+          }
+          if (typeof mouseEvent.buttons === 'number' && ((mouseEvent.buttons & 2) === 2 || (mouseEvent.buttons & 4) === 4)) {
+            return true;
+          }
+        }
+
+        const target = (mouseEvent?.target as Element) ?? null;
         return target === svgRef.current || target === workspaceRef.current;
       })
       .scaleExtent([0.1, 10])

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -1401,7 +1401,6 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
     const bbox = (element.node() as SVGGraphicsElement).getBBox();
     const width = data.width ?? bbox.width;
     const height = data.height ?? bbox.height;
-    const height = data.height ?? bbox.height;
     const transform: TransformValues = data.transform ?? defaultTransform();
     data.transform = transform;
 

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -1470,7 +1470,7 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
     data.transform = transform;
     element.append('text')
         .attr('class', 'rotate-handle')
-        .text('\u21bb')
+        .text('\u27f3')
         .style('cursor', 'grab')
         .style('user-select', 'none')
         .attr('vector-effect', 'non-scaling-stroke')
@@ -1649,33 +1649,54 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
         globalInit = true;
     }
 
+    let pointerHandled = false;
+
+    const applySelection = (
+        event: MouseEvent | PointerEvent | null,
+        node: Element,
+    ) => {
+        event?.stopPropagation();
+        const element = d3.select(node);
+        const alreadySelected = !!selectedElement && selectedElement.node() === node;
+
+        if (!alreadySelected && selectedElement) {
+            clearSelection();
+        }
+
+        selectedElement = element;
+        addOutline(element);
+        if (!element.classed('line-element')) {
+            addResizeHandle(element, options);
+            ensureConnectHandles(element);
+            if (options.rotatable) {
+                addRotateHandle(element);
+            }
+        }
+        if (debugEnabled) {
+            if (element.select('.component-debug-cross').empty()) {
+                addDebugCross(element);
+            } else {
+                updateDebugCross(element);
+            }
+        }
+
+        updateSelectionDecorations(element);
+        dispatchSelectionChange();
+    };
+
     selection
         .style('cursor', 'pointer')
+        .on('pointerdown.makeResizable', function (event: PointerEvent) {
+            pointerHandled = true;
+            applySelection(event, this);
+        })
         .on('click.makeResizable', function (event: MouseEvent) {
-            event.stopPropagation();
-            const element = d3.select(this);
-
-            if (selectedElement && selectedElement.node() !== this) {
-                clearSelection();
+            if (!pointerHandled) {
+                applySelection(event, this);
+            } else {
+                event.stopPropagation();
             }
-
-            selectedElement = element;
-            addOutline(element);
-            if (!element.classed('line-element')) {
-                addResizeHandle(element, options);
-                ensureConnectHandles(element);
-                if (options.rotatable) {
-                    addRotateHandle(element);
-                }
-            }
-            if (debugEnabled) {
-                if (element.select('.component-debug-cross').empty()) {
-                    addDebugCross(element);
-                } else {
-                    updateDebugCross(element);
-                }
-            }
-            dispatchSelectionChange();
+            pointerHandled = false;
         });
 }
 

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -834,6 +834,62 @@ export function makeDraggable(selection: Selection<any, any, any, any>) {
 
 let selectedElement: Selection<any, any, any, any> | null = null;
 let globalInit = false;
+const resizeOptionsByElement = new WeakMap<Element, ResizeOptions>();
+
+function getResizeOptions(node: Element | null): ResizeOptions {
+    if (!node) return {};
+    return resizeOptionsByElement.get(node) ?? {};
+}
+
+function findResizableAncestor(start: Element | null): Element | null {
+    let current: Element | null = start;
+    while (current) {
+        if (resizeOptionsByElement.has(current)) {
+            return current;
+        }
+        const parentElement = current.parentElement;
+        if (parentElement) {
+            current = parentElement;
+            continue;
+        }
+        const parentNode = current.parentNode;
+        current = parentNode instanceof Element ? parentNode : null;
+    }
+    return null;
+}
+
+function applySelectionToElement(element: Selection<any, any, any, any>) {
+    const node = element.node();
+    if (!node) return;
+
+    const alreadySelected = !!selectedElement && selectedElement.node() === node;
+    if (!alreadySelected && selectedElement) {
+        clearSelection();
+    }
+
+    selectedElement = element;
+
+    addOutline(element);
+    if (!element.classed('line-element')) {
+        const options = getResizeOptions(node);
+        addResizeHandle(element, options);
+        ensureConnectHandles(element);
+        if (options.rotatable) {
+            addRotateHandle(element);
+        }
+    }
+
+    if (debugEnabled) {
+        if (element.select('.component-debug-cross').empty()) {
+            addDebugCross(element);
+        } else {
+            updateDebugCross(element);
+        }
+    }
+
+    updateSelectionDecorations(element);
+    dispatchSelectionChange();
+}
 
 function dispatchSelectionChange() {
     window.dispatchEvent(new CustomEvent('stickyselectionchange', { detail: selectedElement?.node() || null }));
@@ -1646,53 +1702,45 @@ export function makeResizable(selection: Selection<any, any, any, any>, options:
             }
         });
 
+        d3.select(window).on('pointerdown.makeResizableSelect', (event: PointerEvent) => {
+            if (event.button !== 0) return;
+            const target = event.target as Element | null;
+            if (!target) return;
+            const ancestor = findResizableAncestor(target);
+            if (!ancestor) return;
+            if (selectedElement && selectedElement.node() === ancestor) {
+                return;
+            }
+            applySelectionToElement(d3.select(ancestor));
+        });
+
         globalInit = true;
     }
 
     let pointerHandled = false;
 
-    const applySelection = (
-        event: MouseEvent | PointerEvent | null,
-        node: Element,
-    ) => {
-        event?.stopPropagation();
-        const element = d3.select(node);
-        const alreadySelected = !!selectedElement && selectedElement.node() === node;
+    selection.each(function () {
+        const existing = resizeOptionsByElement.get(this) ?? {};
+        const merged: ResizeOptions = { ...existing, ...(options ?? {}) };
+        resizeOptionsByElement.set(this, merged);
+    });
 
-        if (!alreadySelected && selectedElement) {
-            clearSelection();
+    const selectFromEvent = (event: Event | null, node: Element) => {
+        if (event && !(event instanceof PointerEvent)) {
+            event.stopPropagation();
         }
-
-        selectedElement = element;
-        addOutline(element);
-        if (!element.classed('line-element')) {
-            addResizeHandle(element, options);
-            ensureConnectHandles(element);
-            if (options.rotatable) {
-                addRotateHandle(element);
-            }
-        }
-        if (debugEnabled) {
-            if (element.select('.component-debug-cross').empty()) {
-                addDebugCross(element);
-            } else {
-                updateDebugCross(element);
-            }
-        }
-
-        updateSelectionDecorations(element);
-        dispatchSelectionChange();
+        applySelectionToElement(d3.select(node));
     };
 
     selection
         .style('cursor', 'pointer')
         .on('pointerdown.makeResizable', function (event: PointerEvent) {
             pointerHandled = true;
-            applySelection(event, this);
+            selectFromEvent(event, this);
         })
         .on('click.makeResizable', function (event: MouseEvent) {
             if (!pointerHandled) {
-                applySelection(event, this);
+                selectFromEvent(event, this);
             } else {
                 event.stopPropagation();
             }

--- a/src/d3-ext.ts
+++ b/src/d3-ext.ts
@@ -1401,6 +1401,7 @@ function addResizeHandle(element: Selection<any, any, any, any>, options: Resize
     const bbox = (element.node() as SVGGraphicsElement).getBBox();
     const width = data.width ?? bbox.width;
     const height = data.height ?? bbox.height;
+    const height = data.height ?? bbox.height;
     const transform: TransformValues = data.transform ?? defaultTransform();
     data.transform = transform;
 
@@ -1522,6 +1523,7 @@ function addRotateHandle(element: Selection<any, any, any, any>) {
     const data: any = element.datum();
     const bbox = (element.node() as SVGGraphicsElement).getBBox();
     const width = data.width ?? bbox.width;
+    const height = data.height ?? bbox.height;
     const transform: TransformValues = data.transform ?? defaultTransform();
     data.transform = transform;
     element.append('text')


### PR DESCRIPTION
## Summary
- allow the guitar board zoom behavior to pan with middle or right mouse buttons regardless of hovered element
- remove the duplicate `defaultBackgroundFeather` import from the guitar board component
- disable the browser context menu so right-click dragging is uninterrupted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebc030aea0832eb2a3a1334c6b1fff